### PR TITLE
Declare encoding as UTF-8

### DIFF
--- a/mapps.py
+++ b/mapps.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json, webbrowser
 
 import requests


### PR DESCRIPTION
Added the line "# -*- coding: utf-8 -*-" to the beginning of the mapps.py page to prevent the following error
SyntaxError: Non-ASCII character '\xc2' in file /home/abraham/.local/share/jarvis/mapps.py on line 35, but no encoding declared