### PR TITLE
[HELP WANTED] Two word cmds warnings

### DIFF
--- a/Jarvis/Jarvis.py
+++ b/Jarvis/Jarvis.py
@@ -50,7 +50,7 @@ class Jarvis(CmdInterpreter):
         elif len(words) == 1:
             # if the action is a dict action, the command should contain more than one word
             # such as 'disable sound' or 'please, could you check the weather in Madrid'
-            dict_actions = [action.keys()[0] for action in self.actions if type(action) == dict]
+            dict_actions = [action.keys()[0] for action in self.actions if isinstance(action, dict)]
             if words[0] in dict_actions:
                 self.default(words)
             pass

--- a/Jarvis/Jarvis.py
+++ b/Jarvis/Jarvis.py
@@ -48,6 +48,11 @@ class Jarvis(CmdInterpreter):
         if len(words) == 0:
             line = "None"
         elif len(words) == 1:
+            # if the action is a dict action, the command should contain more than one word
+            # such as 'disable sound' or 'please, could you check the weather in Madrid'
+            dict_actions = [action.keys()[0] for action in self.actions if type(action) == dict]
+            if words[0] in dict_actions:
+                self.default(words)
             pass
         elif (len(words) > 2) or (words[0] not in self.actions):
             line = self.parse_input(line)
@@ -129,8 +134,8 @@ class Jarvis(CmdInterpreter):
                         output += " " + " ".join(command_arguments)
             # make Jarvis complain if none of the words_remaining are part
             # of the word values (as in 'enable cat' or 'check whatever you fancy')
-            if output == word:
-                self.default(output)
+        if output == word:
+            self.default(output)
         return output
 
     def executor(self):

--- a/Jarvis/Jarvis.py
+++ b/Jarvis/Jarvis.py
@@ -114,8 +114,7 @@ class Jarvis(CmdInterpreter):
                 break
         return output
 
-    @staticmethod
-    def _generate_output_if_dict(action, word, words_remaining):
+    def _generate_output_if_dict(self, action, word, words_remaining):
         """Generates the correct output if action is a dict"""
         output = word
 
@@ -128,6 +127,10 @@ class Jarvis(CmdInterpreter):
                     if argument == value:
                         output += " " + argument
                         output += " " + " ".join(command_arguments)
+            # make Jarvis complain if none of the words_remaining are part
+            # of the word values (as in 'enable cat' or 'check whatever you fancy')
+            if output == word:
+                self.default(output)
         return output
 
     def executor(self):

--- a/Jarvis/Jarvis.py
+++ b/Jarvis/Jarvis.py
@@ -53,7 +53,6 @@ class Jarvis(CmdInterpreter):
             dict_actions = [action.keys()[0] for action in self.actions if isinstance(action, dict)]
             if words[0] in dict_actions:
                 self.default(words)
-            pass
         elif (len(words) > 2) or (words[0] not in self.actions):
             line = self.parse_input(line)
         return line

--- a/Jarvis/tests/test_default.py
+++ b/Jarvis/tests/test_default.py
@@ -9,7 +9,7 @@ class DefaultTest(unittest.TestCase):
         self.jarvis = Jarvis()
         self.action = {"enable": ("sound",)}
 
-    # check that default is called if the value of the word dictionary is not found in
+    # check that default is called if the second word of a two word command is not found in
     # the words_remaining ("enable cat and dog" instead of "enable your sound please")
     def test_call_default_for_wrong_dict_cmd(self):
         with patch.object(self.jarvis, 'default') as default_mock:
@@ -20,3 +20,25 @@ class DefaultTest(unittest.TestCase):
         with patch.object(self.jarvis, 'default') as default_mock:
             self.jarvis._generate_output_if_dict(self.action, "enable", ["your", "sound", "please"])
             self.assertFalse(default_mock.called)
+
+    # check that default is called if the first word of a several word command is used alone
+    def test_call_default_if_1_word_only_dict_cmd(self):
+        with patch.object(self.jarvis, 'default') as default_mock:
+            self.jarvis.precmd("enable")
+            self.assertTrue(default_mock.called)
+
+    # check that default is called if the first word of a several word command is used
+    # with words before it, but no words after
+    def test_call_default_for_words_before_1_word_dict_cmd(self):
+        args = (self.action, "enable", [])
+
+        # check that _generate_output_if_dict is called with the expected arguments
+        with patch.object(self.jarvis, '_generate_output_if_dict') as generate_output_mock:
+            self.jarvis.precmd("please, could you enable")
+            self.assertTrue(generate_output_mock.called)
+            generate_output_mock.assert_called_once_with(*args)
+
+        # check that _generate_output_if_dict calls default given these arguments
+        with patch.object(self.jarvis, 'default') as default_mock:
+            self.jarvis._generate_output_if_dict(*args)
+            self.assertTrue(default_mock.called)

--- a/Jarvis/tests/test_default.py
+++ b/Jarvis/tests/test_default.py
@@ -1,0 +1,22 @@
+import unittest
+from Jarvis import Jarvis
+from mock import patch
+
+
+class DefaultTest(unittest.TestCase):
+
+    def setUp(self):
+        self.jarvis = Jarvis()
+        self.action = {"enable": ("sound",)}
+
+    # check that default is called if the value of the word dictionary is not found in
+    # the words_remaining ("enable cat and dog" instead of "enable your sound please")
+    def test_call_default_for_wrong_dict_cmd(self):
+        with patch.object(self.jarvis, 'default') as default_mock:
+            self.jarvis._generate_output_if_dict(self.action, "enable", ["cat", "and", "dog"])
+            self.assertTrue(default_mock.called)
+
+    def test_dont_call_default_for_correct_dict_cmd(self):
+        with patch.object(self.jarvis, 'default') as default_mock:
+            self.jarvis._generate_output_if_dict(self.action, "enable", ["your", "sound", "please"])
+            self.assertFalse(default_mock.called)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ SpeechRecognition==3.6.3
 pyttsx == 1.1
 aiml
 python-dateutil
+mock==2.0.0


### PR DESCRIPTION
Calling "default" as error message function when the first word of a several word command can be found in the prompt to Jarvis, but not the rest of required words. See issue #92 