### PR TITLE
Weather for current location as default when location not found after 'check weather'

### DIFF
--- a/Jarvis/packages/weatherIn.py
+++ b/Jarvis/packages/weatherIn.py
@@ -2,11 +2,13 @@
 import json
 import requests
 import mapps
+import packages.weather_pinpoint as pinpoint
+from packages.memory.memory import Memory
 from colorama import Fore
 
 
 def main(self, s):
-    loc = s.replace('weather ', '').replace('in ', '')  # Trim input command to get only the location
+    loc = s.replace('weather', '').replace('in ', '').strip()  # Trim input command to get only the location
 
     # Checks country
     country = mapps.getLocation()['country_name']
@@ -28,6 +30,11 @@ def main(self, s):
         unit = ' ºC in '
     r = requests.get(send_url)
     j = json.loads(r.text)
+
+    if 'message' in j.keys() and ('city not found' in j['message'] or 'Nothing to geocode' in j['message']):
+        return pinpoint.main(Memory(), self, s)
+
     temperature = j['main']['temp']
     description = j['weather'][0]['main']
-    print(Fore.BLUE + "It's " + str(temperature) + unit + str(loc.title()) + " (" + str(description) + ")" + Fore.RESET)
+    location = j['name']
+    print(Fore.BLUE + "It's " + str(temperature) + unit + str(location.title()) + " (" + str(description) + ")" + Fore.RESET)

--- a/Jarvis/tests/test_weatherIn.py
+++ b/Jarvis/tests/test_weatherIn.py
@@ -1,13 +1,9 @@
 import unittest
-from Jarvis import Jarvis
 from mock import patch
 from packages import weather_pinpoint, weatherIn
 
 
 class weatherInTest(unittest.TestCase):
-
-    def setUp(self):
-        self.jarvis = Jarvis()
 
     def test_pinpoint_is_called_if_no_location_is_found(self):
         with patch.object(weather_pinpoint, 'main') as pinpoint_mock:

--- a/Jarvis/tests/test_weatherIn.py
+++ b/Jarvis/tests/test_weatherIn.py
@@ -1,0 +1,19 @@
+import unittest
+from Jarvis import Jarvis
+from mock import patch
+from packages import weather_pinpoint, weatherIn
+
+
+class weatherInTest(unittest.TestCase):
+
+    def setUp(self):
+        self.jarvis = Jarvis()
+
+    def test_pinpoint_is_called_if_no_location_is_found(self):
+        with patch.object(weather_pinpoint, 'main') as pinpoint_mock:
+            weatherIn.main(self, 'weather in NowhereReally')
+            self.assertTrue(pinpoint_mock.called)
+
+        with patch.object(weather_pinpoint, 'main') as pinpoint_mock:
+            weatherIn.main(self, 'weather')
+            self.assertTrue(pinpoint_mock.called)

--- a/contributors.md
+++ b/contributors.md
@@ -9,3 +9,4 @@
 * bwh91
 * AnderRasoVazquez
 * LuisFSilva
+* anaisabel7


### PR DESCRIPTION
The weather_pinpoint function is called as default when the location included after 'check weather' cannot be understood or when no location is provided. Corresponding tests are added.
Proposed solution to issue #94 