### PR TITLE
Replaced print() calls in Jarvis.py and CmdInterpreter.py with print_say()

### DIFF
--- a/Jarvis/CmdInterpreter.py
+++ b/Jarvis/CmdInterpreter.py
@@ -414,12 +414,12 @@ class CmdInterpreter(Cmd):
 
     def do_os(self, s):
         """Displays information about your operating system."""
-        print(Fore.BLUE + '[!] Operating System Information' + Fore.RESET)
-        print(Fore.GREEN + '[*] ' + sys() + Fore.RESET)
-        print(Fore.GREEN + '[*] ' + release() + Fore.RESET)
-        print(Fore.GREEN + '[*] ' + dist()[0] + Fore.RESET)
+        print_say('[!] Operating System Information', self, Fore.BLUE)
+        print_say('[*] ' + sys(), self, Fore.GREEN)
+        print_say('[*] ' + release(), self, Fore.GREEN)
+        print_say('[*] ' + dist()[0], self, Fore.GREEN)
         for _ in architecture():
-            print(Fore.GREEN + '[*] ' + _ + Fore.RESET)
+            print_say('[*] ' + _, self, Fore.GREEN)
 
     def help_os(self):
         """Displays information about your operating system."""

--- a/Jarvis/Jarvis.py
+++ b/Jarvis/Jarvis.py
@@ -40,7 +40,7 @@ class Jarvis(CmdInterpreter):
         """Jarvis let's you know if an error has occurred."""
         if self.enable_voice:
             self.speech.text_to_speech("I could not identify your command")
-        print(Fore.RED + "I could not identify your command..." + Fore.RESET)
+        print_say("I could not identify your command...", self, Fore.RED)
 
     def precmd(self, line):
         """Hook that executes before every command."""


### PR DESCRIPTION
As requested in Issue #80, I replaced some of the calls to print() with print_say() in the class definitions of Jarvis and CmdInterpreter.