### PR TITLE
Solving the problems with the near command

### DIFF
--- a/Jarvis/Jarvis.py
+++ b/Jarvis/Jarvis.py
@@ -17,7 +17,7 @@ from CmdInterpreter import CmdInterpreter
 """
 
 
-class Jarvis(CmdInterpreter):
+class Jarvis(CmdInterpreter, object):
     # We use this variable at Breakpoint #1.
     # We use this in order to allow Jarvis say "Hi", only at the first
     # interaction.
@@ -106,6 +106,10 @@ class Jarvis(CmdInterpreter):
                     action_found = True
                     output = self._generate_output_if_dict(action, word, words_remaining)
                     break
+                # For the 'near' keyword, the words before 'near' are also needed
+                elif word == "near":
+                    initial_words = words[:words.index('near')]
+                    output = word + " " + " ".join(initial_words + ["|"] + words_remaining)
                 elif word == action:  # command name exists
                     action_found = True
                     output = word + " " + " ".join(words_remaining)

--- a/Jarvis/packages/near_me.py
+++ b/Jarvis/packages/near_me.py
@@ -4,11 +4,11 @@ import mapps
 
 def main(data):
     wordList = data.split()
-    things = " ".join(wordList[0:wordIndex(data, "near")])
+    things = " ".join(wordList[0:wordIndex(data, "|")])
     if " me" in data:
         city = 0
     else:
         wordList = data.split()
-        city = " ".join(wordList[wordIndex(data, "near") + 1:])
+        city = " ".join(wordList[wordIndex(data, "|") + 1:])
         print(city)
     mapps.searchNear(things, city)

--- a/Jarvis/tests/test_near_me.py
+++ b/Jarvis/tests/test_near_me.py
@@ -1,0 +1,16 @@
+import unittest
+from mock import patch
+from packages import near_me, mapps
+
+
+class NearMeTest(unittest.TestCase):
+
+    def setUp(self):
+        self.things = 'charities'
+        self.city = 'Valencia'
+
+    @patch.object(mapps, 'searchNear')
+    def test_what_to_search_where_is_passed_to_mapps(self, mock_search_near):
+        data = "{} | {}".format(self.things, self.city)
+        near_me.main(data)
+        mock_search_near.assert_called_once_with(self.things, self.city)

--- a/Jarvis/tests/test_parser.py
+++ b/Jarvis/tests/test_parser.py
@@ -32,5 +32,11 @@ class ParserTest(unittest.TestCase):
         parsed_input = self.jarvis.parse_input(user_input).split()
         self.assertEqual(["say", "i'm", "a", "robot"], parsed_input[0:])
 
+    def test_near(self):
+        user_input = "charities near Valencia"
+        parsed_input = self.jarvis.parse_input(user_input).split()
+        self.assertEqual(["near", "charities", "|", "valencia"], parsed_input[0:])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The general parsing of the command within Jarvis meant, for the near command, the information previous to the 'near' keyword was not passed to the near_me.main function, which requires it.
An example is in a command such as `restaurants near me`, the word `restaurants` was not passed to near_me.main.

In this PR, the information previous to 'near' is passed to near_me.main.
The expected syntax of the data passed to near_me.main was also slightly altered to better match the current processing of the command information within Jarvis (i.e. the keyword --- such as 'near' --- is not passed to the do_xxx functions).

This should solve issue #100 