### PR TITLE
add missing notify2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pyttsx == 1.1
 aiml
 python-dateutil
 mock==2.0.0
+notify2


### PR DESCRIPTION
After running ./setup.sh and trying to use jarvis I got the error:
ImportError: No module named notify2.

Adding notify2 in requirements.txt file to solve it.