### PR TITLE
fix crashing in 'near' command when using without parameter

### DIFF
--- a/jarviscli/packages/near_me.py
+++ b/jarviscli/packages/near_me.py
@@ -1,10 +1,17 @@
 from utilities.GeneralUtilities import wordIndex
+import CmdInterpreter
 import mapps
 
 
 def main(data):
     word_list = data.split()
-    things = " ".join(word_list[0:wordIndex(data, "|")])
+    try:
+        things = " ".join(word_list[0:wordIndex(data, "|")])
+    except ValueError:
+        cmd = CmdInterpreter.CmdInterpreter("", "")
+        cmd.help_near()
+        return
+
     if " me" in data:
         city = 0
     else:


### PR DESCRIPTION
When typing 'near' command without any parameter, a ValueError is raised
and jarvis crashes.

This patch shows the 'near' help message instead of crashing.