### PR TITLE
macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ jarviscli/packages/memory/memory.json
 *.brn
 dist/
 build/
+env/

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -8,7 +8,9 @@ from colorama import Fore
 from requests import ConnectionError
 
 from utilities import voice
-from utilities.GeneralUtilities import print_say
+from utilities.GeneralUtilities import (
+    IS_MACOS, MACOS, print_say, unsupported
+)
 from packages.music import play
 from packages.todo import todoHandler
 from packages.reminder import reminder_handler, reminder_quit
@@ -204,7 +206,13 @@ class CmdInterpreter(Cmd):
         """Decreases you speakers' sound."""
         # TODO si solo ponemos decrease que pase algo
         if s == "volume":
-            system("pactl -- set-sink-volume 0 -10%")
+            if IS_MACOS:
+                system(
+                    'osascript -e "set volume output volume '
+                    '(output volume of (get volume settings) - 10) --100%"'
+                )
+            else:
+                system("pactl -- set-sink-volume 0 -10%")
 
     def help_decrease(self):
         """Print help about decrease command."""
@@ -217,7 +225,13 @@ class CmdInterpreter(Cmd):
     def do_increase(self, s):
         """Increases you speakers' sound."""
         if s == "volume":
-            system("pactl -- set-sink-volume 0 +3%")
+            if IS_MACOS:
+                system(
+                    'osascript -e "set volume output volume '
+                    '(output volume of (get volume settings) + 10) --100%"'
+                )
+            else:
+                system("pactl -- set-sink-volume 0 +3%")
 
     def help_increase(self):
         """Print help about increase command."""
@@ -333,6 +347,7 @@ class CmdInterpreter(Cmd):
         """Completions for enable command"""
         return self.get_completions("hotspot", text)
 
+    @unsupported(platform=MACOS)
     def do_movies(self, s):
         """Jarvis will find a good movie for you."""
         try:
@@ -347,20 +362,23 @@ class CmdInterpreter(Cmd):
         """Print help about movies command."""
         print_say("Jarvis will find a good movie for you", self)
 
+    @unsupported(platform=MACOS)
     def do_music(self, s):
         """Jarvis will find you a good song to relax!"""
         play(s)
 
+    @unsupported(platform=MACOS)
     def help_music(self):
         """Print help about music command."""
         print_say("Jarvis will find you the song you want", self)
         print_say("-- Example:", self)
         print_say("\tmusic wonderful tonight", self)
 
+    @unsupported(platform=MACOS)
     def do_play(self, s):
         """Jarvis will find you a good song to relax!"""
         play(s)
-
+    @unsupported(platform=MACOS)
     def help_play(self):
         """Print help about play command."""
         print_say("Jarvis will find you the song you want", self)
@@ -402,8 +420,11 @@ class CmdInterpreter(Cmd):
     def do_open(self, s):
         """Jarvis will open the camera for you."""
         if "camera" in s:
-            print_say("Opening cheese.......", self, Fore.RED)
-            system("cheese")
+            if IS_MACOS:
+                system('open /Applications/Photo\ Booth.app')
+            else:
+                print_say("Opening cheese.......", self, Fore.RED)
+                system("cheese")
 
     def help_open(self):
         """Print help about open command."""

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -331,6 +331,7 @@ class CmdInterpreter(Cmd):
         print_say("-- Example:", self)
         print_say("\tevaluate 3 + 5", self)
 
+    @unsupported(platform=MACOS)
     def do_hotspot(self, s):
         """Jarvis will set up your own hotspot."""
         if "start" in s:
@@ -338,6 +339,7 @@ class CmdInterpreter(Cmd):
         elif "stop" in s:
             system("sudo ap-hotspot stop")
 
+    @unsupported(platform=MACOS)
     def help_hotspot(self):
         """Print help about hotspot commando."""
         print_say("start: Jarvis will set up your own hotspot.", self)
@@ -358,6 +360,7 @@ class CmdInterpreter(Cmd):
                 Fore.RED + "What do you want to watch?\n" + Fore.RESET)
         system("ims " + movie_name)
 
+    @unsupported(platform=MACOS)
     def help_movies(self):
         """Print help about movies command."""
         print_say("Jarvis will find a good movie for you", self)
@@ -531,7 +534,7 @@ class CmdInterpreter(Cmd):
 
     def help_enable(self):
         """Displays help about enable command"""
-        print_say("Let Jarvis use his voice.", self)
+        print_say("sound: Let Jarvis use his voice.", self)
 
     def complete_enable(self, text, line, begidx, endidx):
         """Completions for enable command"""
@@ -544,7 +547,7 @@ class CmdInterpreter(Cmd):
 
     def help_disable(self):
         """Displays help about disable command"""
-        print_say("Deny Jarvis to use his voice.", self)
+        print_say("sound: Deny Jarvis his voice.", self)
 
     def complete_disable(self, text, line, begidx, endidx):
         """Completions for check command"""

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -381,6 +381,7 @@ class CmdInterpreter(Cmd):
     def do_play(self, s):
         """Jarvis will find you a good song to relax!"""
         play(s)
+
     @unsupported(platform=MACOS)
     def help_play(self):
         """Print help about play command."""

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -33,7 +33,8 @@ class Jarvis(CmdInterpreter, object):
     first_reaction_text += Fore.RESET + Fore.RED + 'enable sound' + Fore.RESET
     first_reaction_text += "\n"
     prompt = (
-        Fore.RED + "{} Hi, what can I do for you?\n".format(PROMPT_CHAR) + Fore.RESET
+        Fore.RED +
+        "{} Hi, what can I do for you?\n".format(PROMPT_CHAR) + Fore.RESET
     )
 
     # This can be used to store user specific data
@@ -67,7 +68,8 @@ class Jarvis(CmdInterpreter, object):
         """Hook that executes after every command."""
         if self.first_reaction:
             self.prompt = (
-                Fore.RED + "{} What can i do for you?\n".format(PROMPT_CHAR) + Fore.RESET
+                Fore.RED +
+                "{} What can i do for you?\n".format(PROMPT_CHAR) + Fore.RESET
             )
             self.first_reaction = False
         if self.enable_voice:

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -1,6 +1,10 @@
+# -*- coding: utf-8 -*-
+
 from colorama import Fore
 from utilities.GeneralUtilities import print_say
 from CmdInterpreter import CmdInterpreter
+
+PROMPT_CHAR = '~>'
 
 """
     AUTHORS' SCOPE:
@@ -23,12 +27,14 @@ class Jarvis(CmdInterpreter, object):
     # interaction.
     first_reaction_text = ""
     first_reaction_text += Fore.BLUE + \
-        'Jarvi\'s sound is by default disabled.' + Fore.RESET
+        'Jarvis\' sound is by default disabled.' + Fore.RESET
     first_reaction_text += "\n"
     first_reaction_text += Fore.BLUE + 'In order to let Jarvis talk out loud type: '
     first_reaction_text += Fore.RESET + Fore.RED + 'enable sound' + Fore.RESET
     first_reaction_text += "\n"
-    prompt = Fore.RED + "~> Hi, what can i do for you?\n" + Fore.RESET
+    prompt = (
+        Fore.RED + "{} Hi, what can I do for you?\n".format(PROMPT_CHAR) + Fore.RESET
+    )
 
     # This can be used to store user specific data
 
@@ -60,7 +66,9 @@ class Jarvis(CmdInterpreter, object):
     def postcmd(self, stop, line):
         """Hook that executes after every command."""
         if self.first_reaction:
-            self.prompt = self.prompt = Fore.RED + "~> What can i do for you?\n" + Fore.RESET
+            self.prompt = (
+                Fore.RED + "{} What can i do for you?\n".format(PROMPT_CHAR) + Fore.RESET
+            )
             self.first_reaction = False
         if self.enable_voice:
             self.speech.text_to_speech("What can i do for you?\n")

--- a/jarviscli/packages/evaluator.py
+++ b/jarviscli/packages/evaluator.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from utilities.GeneralUtilities import print_say
 from colorama import Fore
+from math import *  # to give eval access to all of math lib
 
 
 def calc(s, self):

--- a/jarviscli/packages/picshow.py
+++ b/jarviscli/packages/picshow.py
@@ -4,6 +4,6 @@ import webbrowser
 
 def showpics(string):
     string = string.split(" ")
-    query = string[4]
+    query = string[-1]
     url = "https://www.google.com/search?tbm=isch&q={}".format(query)
     webbrowser.open(url)

--- a/jarviscli/packages/reminder.py
+++ b/jarviscli/packages/reminder.py
@@ -3,13 +3,17 @@
 from datetime import datetime as dt
 from uuid import uuid4
 from threading import Timer
-import notify2
 
 
 from fileHandler import write_file, read_file, str2date
 from utilities.lexicalSimilarity import score_sentence, compare_sentence
 from utilities.textParser import parse_number, parse_date
-from utilities.GeneralUtilities import error, info
+from utilities.GeneralUtilities import (
+    error, info, MACOS, IS_MACOS, unsupported
+)
+
+if not IS_MACOS:
+    import notify2
 
 
 def sort(data):
@@ -148,6 +152,7 @@ def handler_clear(data):
     write_file("reminderlist.txt", reminderList)
 
 
+@unsupported(platform=MACOS)
 def reminder_handler(data):
     """
     Handle the command string for reminders.
@@ -185,6 +190,7 @@ def reminder_handler(data):
     globals()[action](data)
 
 
+@unsupported(platform=MACOS, silent=True)
 def reminder_quit():
     """
     This function has to be called when shutting down. It terminates all waiting threads.
@@ -196,17 +202,17 @@ def reminder_quit():
         for index, el in timerList.items():
             el.cancel()
 
-
-timerList = {}
-reminderList = read_file("reminderlist.txt", {'items': []})
-reminderList['items'] = sort(reminderList['items'])
-reminderList['items'] = [i for i in reminderList['items'] if not i['hidden']]
-notify2.init("Jarvis")
-for e in reminderList['items']:
-    e['time'] = str2date(e['time'])
-    waitTime = e['time'] - dt.now()
-    n = notify2.Notification(e['name'])
-    n.set_urgency(0)
-    timerList[e['uuid']] = Timer(
-        waitTime.total_seconds(), showAlarm, [n, e['name']])
-    timerList[e['uuid']].start()
+if not IS_MACOS:
+    timerList = {}
+    reminderList = read_file("reminderlist.txt", {'items': []})
+    reminderList['items'] = sort(reminderList['items'])
+    reminderList['items'] = [i for i in reminderList['items'] if not i['hidden']]
+    notify2.init("Jarvis")
+    for e in reminderList['items']:
+        e['time'] = str2date(e['time'])
+        waitTime = e['time'] - dt.now()
+        n = notify2.Notification(e['name'])
+        n.set_urgency(0)
+        timerList[e['uuid']] = Timer(
+            waitTime.total_seconds(), showAlarm, [n, e['name']])
+        timerList[e['uuid']].start()

--- a/jarviscli/packages/reminder.py
+++ b/jarviscli/packages/reminder.py
@@ -202,11 +202,13 @@ def reminder_quit():
         for index, el in timerList.items():
             el.cancel()
 
+
 if not IS_MACOS:
     timerList = {}
     reminderList = read_file("reminderlist.txt", {'items': []})
     reminderList['items'] = sort(reminderList['items'])
-    reminderList['items'] = [i for i in reminderList['items'] if not i['hidden']]
+    reminderList['items'] = [
+        i for i in reminderList['items'] if not i['hidden']]
     notify2.init("Jarvis")
     for e in reminderList['items']:
         e['time'] = str2date(e['time'])

--- a/jarviscli/packages/systemOptions.py
+++ b/jarviscli/packages/systemOptions.py
@@ -2,12 +2,21 @@
 import os
 import subprocess
 
+from utilities.GeneralUtilities import IS_MACOS
+
 
 def turn_off_screen():
-    os.system('xset dpms force off')
+    if IS_MACOS:
+        os.system('pmset displaysleepnow')
+    else:
+        os.system('xset dpms force off')
 
 
 def update_system():
+    if IS_MACOS:
+        os.system('brew upgrade && brew update')
+        return
+
     release = subprocess.check_output('cat /etc/lsb-rel'
                                       + 'ease | grep'
                                       + ' DISTRIB_ID=', shell=True)

--- a/jarviscli/tests/test_help.py
+++ b/jarviscli/tests/test_help.py
@@ -1,6 +1,13 @@
 import unittest
 import CmdInterpreter
 from mock import patch
+from utilities.GeneralUtilities import IS_MACOS
+
+MACOS_BLACKLIST = {
+    'movies',
+    'music',
+    'play',
+}
 
 
 class HelpTest(unittest.TestCase):
@@ -22,4 +29,7 @@ class HelpTest(unittest.TestCase):
                 help_cmd_name = "help_{}".format(action)
                 help_cmd = getattr(self.CI, help_cmd_name)
                 help_cmd(self.CI_instance)
-                mock_print_say.assert_called()
+                if action in MACOS_BLACKLIST and IS_MACOS:
+                    pass
+                else:
+                    mock_print_say.assert_called()

--- a/jarviscli/utilities/GeneralUtilities.py
+++ b/jarviscli/utilities/GeneralUtilities.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
+import sys
+from functools import wraps
 
 from colorama import Fore
+
+MACOS = 'darwin'
+IS_MACOS = sys.platform == MACOS
 
 
 def wordIndex(data, word):
@@ -41,3 +46,19 @@ def warning(string):
 
 def info(string):
     print(Fore.BLUE + string + Fore.RESET)
+
+
+def unsupported(platform, silent=False):
+    def noop_wrapper(func):
+        def wrapped(*args, **kwargs):
+            if sys.platform == platform:
+                if not silent:
+                    print(
+                        Fore.RED
+                        + 'Command is unsupported for platform `{}`'.format(
+                            sys.platform
+                        ) + Fore.RESET)
+            else:
+                func(*args, **kwargs)
+        return wrapped
+    return noop_wrapper

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -1,4 +1,10 @@
-import pyttsx
+from utilities.GeneralUtilities import IS_MACOS
+
+
+if IS_MACOS:
+    from os import system
+else:
+    import pyttsx
 
 '''
     ABOUT: This class is the Voice of Jarvis.
@@ -15,8 +21,9 @@ class Voice:
         """
         This constructor creates a pyttsx object.
         """
-        self.create()
-        self.engine = None
+        if not IS_MACOS:
+            self.create()
+            self.engine = None
 
     def create(self):
         """
@@ -44,14 +51,9 @@ class Voice:
         :return: Nothing to return.
         """
         if first_run:
-            self.engine.say('Hi, what can i do for you?')
-            self.engine.runAndWait()
-            self.destroy()
+            self.text_to_speech('Hi, what can I do for you?')
         else:
-            self.create()
-            self.engine.say('What can i do for you?')
-            self.engine.runAndWait()
-            self.destroy()
+            self.text_to_speech('What can i do for you?')
 
     def text_to_speech(self, speech):
         """
@@ -59,10 +61,13 @@ class Voice:
         :param speech: The text we want Jarvis to generate as audio
         :return: Nothing to return.
         """
-        self.create()
-        self.engine.say(speech)
-        self.engine.runAndWait()
-        self.destroy()
+        if IS_MACOS:
+            system('say {}'.format(speech))
+        else:
+            self.create()
+            self.engine.say(speech)
+            self.engine.runAndWait()
+            self.destroy()
 
 
 '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,12 @@ packaging==16.8
 pyowm==2.6.1
 pyparsing==2.2.0
 PySocks==1.6.6
-requests==2.13.0
+cryptography==1.8.1
+requests[security]==2.13.0
 six==1.10.0
 SpeechRecognition==3.6.3
 pyttsx == 1.1
 aiml
 python-dateutil
 mock==2.0.0
+pync==1.6.1

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+UNAME=$(uname -s)
+if [[ "$UNAME" == "Darwin" ]]; then
+  brew install ffmpeg
+  brew install openssl
+  virtualenv env
+  . env/bin/activate
+  pip install -r requirements.txt
+  exit 0
+fi
+
 OS=$(lsb_release -si)
 if [[ "$OS" == "Fedora" ]]; then
   sudo dnf install ffmpeg
@@ -16,4 +26,6 @@ elif [[ "$OS" == "Kali" ]]; then
   pip install -r requirements.txt
 else
   echo "Operating System not supported"
+  exit 1
 fi
+exit 0


### PR DESCRIPTION
- Enable many of Jarvis' functions on macOS
- macOS setup script
- Add `unsupported` decorator for features that are not yet fully functional
- Improve `evaluate` by add access to full math lib
- Fix `show` command for `pics`
- Add `requests[security]` to fix `chuck` on macOS
- Add `pync` for future `remind` development