### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pyparsing==2.2.0
 PySocks==1.6.6
 cryptography==1.8.1
 requests[security]==2.13.0
+selenium>=2.33
 six==1.10.0
 SpeechRecognition==3.6.3
 pyttsx == 1.1


### PR DESCRIPTION
Getting this error without selenium package on Mac OS
`python jarviscli
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.12_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.12_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/shivankarmadaan/github/Jarvis/jarviscli/__main__.py", line 2, in <module>
    import Jarvis
  File "jarviscli/Jarvis.py", line 5, in <module>
    from CmdInterpreter import CmdInterpreter
  File "jarviscli/CmdInterpreter.py", line 27, in <module>
    from packages.fb import fb_login
  File "jarviscli/packages/fb.py", line 4, in <module>
    from selenium import webdriver
ImportError: No module named selenium`