### PR TITLE
fixed bug in check weather

### DIFF
--- a/jarviscli/packages/mapps.py
+++ b/jarviscli/packages/mapps.py
@@ -55,10 +55,19 @@ def weather(city=None):
         unit = ' ºC in '
     r = requests.get(send_url)
     j = json.loads(r.text)
-    temperature = j['main']['temp']
-    description = j['weather'][0]['main']
-    print(Fore.BLUE + "It's " + str(temperature) + unit +
-          str(city) + " (" + str(description) + ")" + Fore.RESET)
+
+    # check if the city entered is not found
+    if 'message' in j and j['message'] == 'city not found':
+        print(Fore.BLUE + "City Not Found" + Fore.RESET)
+        return False
+
+    else:
+        temperature = j['main']['temp']
+        description = j['weather'][0]['main']
+        print(Fore.BLUE + "It's " + str(temperature) + unit +
+              str(city) + " (" + str(description) + ")" + Fore.RESET)
+
+    return True
 
 
 def search_near(things, city=0):

--- a/jarviscli/packages/weather_pinpoint.py
+++ b/jarviscli/packages/weather_pinpoint.py
@@ -22,13 +22,14 @@ def main(memory, self, s):
             except:
                 i = input()
             city = i
+        city_found = True
         if s == 'umbrella':
             umbrella.main(str(city))
         else:
-            mapps.weather(str(city))
-
-        memory.update_data('city', city)
-        memory.save()
+            city_found = mapps.weather(str(city))
+        if city_found:
+            memory.update_data('city', city)
+            memory.save()
     else:
         loc = str(location)
         city = mapps.get_location()['city']


### PR DESCRIPTION
When prompted to enter a city to get weather from, if the city was not found, an error would be thrown in the terminal and jarvis crashed. I changed this so that now a proper message of "city not found" is displayed to the user and jarvis continues to prompt the user for input. 