### PR TITLE
Keyword-less calculate

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -684,7 +684,3 @@ class CmdInterpreter(Cmd):
         """Prints help about weather command."""
         print_say(
             "Get information about today's weather in your current location.", self)
-
-    def do_4(self, s):
-        print_say("hello from do 4", self)
-        print_say(s, self)

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -94,6 +94,7 @@ class CmdInterpreter(Cmd):
                         "umbrella",
                         {"update": ("location", "system")},
                         "weather",
+                        "4",
                         )
 
         self.fixed_responses = {"what time is it": "clock",
@@ -683,3 +684,7 @@ class CmdInterpreter(Cmd):
         """Prints help about weather command."""
         print_say(
             "Get information about today's weather in your current location.", self)
+
+    def do_4(self, s):
+        print_say("hello from do 4", self)
+        print_say(s, self)

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -94,7 +94,6 @@ class CmdInterpreter(Cmd):
                         "umbrella",
                         {"update": ("location", "system")},
                         "weather",
-                        "4",
                         )
 
         self.fixed_responses = {"what time is it": "clock",

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -54,6 +54,12 @@ class Jarvis(CmdInterpreter, object):
     def precmd(self, line):
         """Hook that executes before every command."""
         words = line.split()
+
+        # append calculate keyword to front of leading char digit in line
+        if len(words) > 0 and (words[0].isdigit() or line[0] == "-"):
+            line = "calculate " + line
+            words = line.split()
+
         if len(words) == 0:
             line = "None"
         elif len(words) == 1:
@@ -91,6 +97,7 @@ class Jarvis(CmdInterpreter, object):
             data = data.replace("!", "")
             data = data.replace(".", "")
             data = data.replace(",", "")
+
         # Check if Jarvis has a fixed response to this data
         if data in self.fixed_responses:
             output = self.fixed_responses[data]  # change return to output =
@@ -104,7 +111,6 @@ class Jarvis(CmdInterpreter, object):
         :return: returns the action"""
         output = "None"
         action_found = False
-
         words = data.split()
         words_remaining = data.split()  # this will help us to stop the iteration
 
@@ -135,7 +141,10 @@ class Jarvis(CmdInterpreter, object):
     def _generate_output_if_dict(self, action, word, words_remaining):
         """Generates the correct output if action is a dict"""
         output = word
-
+        print("generate")
+        # check if first char is number
+        if words_remaining[0].isdigit():
+            print_say("here", self)
         # command is a dictionary, let's check if remaining words are one of it's completions
         if len(words_remaining) != 0:
             command_arguments = list(words_remaining)  # make a copy
@@ -148,6 +157,7 @@ class Jarvis(CmdInterpreter, object):
             # make Jarvis complain if none of the words_remaining are part
             # of the word values (as in 'enable cat' or 'check whatever you fancy')
         if output == word:
+            print("here again?")
             self.default(output)
         return output
 
@@ -160,5 +170,6 @@ class Jarvis(CmdInterpreter, object):
         or "goodbye command")
         :return: Nothing to return.
         """
+        print("executor")
         self.speak()
         self.cmdloop(self.first_reaction_text)

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -55,7 +55,7 @@ class Jarvis(CmdInterpreter, object):
         """Hook that executes before every command."""
         words = line.split()
 
-        # append calculate keyword to front of leading char digit in line
+        # append calculate keyword to front of leading char digit (or '-') in line
         if len(words) > 0 and (words[0].isdigit() or line[0] == "-"):
             line = "calculate " + line
             words = line.split()

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -141,9 +141,6 @@ class Jarvis(CmdInterpreter, object):
     def _generate_output_if_dict(self, action, word, words_remaining):
         """Generates the correct output if action is a dict"""
         output = word
-        # check if first char is number
-        if words_remaining[0].isdigit():
-            print_say("here", self)
         # command is a dictionary, let's check if remaining words are one of it's completions
         if len(words_remaining) != 0:
             command_arguments = list(words_remaining)  # make a copy

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -141,7 +141,6 @@ class Jarvis(CmdInterpreter, object):
     def _generate_output_if_dict(self, action, word, words_remaining):
         """Generates the correct output if action is a dict"""
         output = word
-        print("generate")
         # check if first char is number
         if words_remaining[0].isdigit():
             print_say("here", self)
@@ -157,7 +156,6 @@ class Jarvis(CmdInterpreter, object):
             # make Jarvis complain if none of the words_remaining are part
             # of the word values (as in 'enable cat' or 'check whatever you fancy')
         if output == word:
-            print("here again?")
             self.default(output)
         return output
 
@@ -170,6 +168,5 @@ class Jarvis(CmdInterpreter, object):
         or "goodbye command")
         :return: Nothing to return.
         """
-        print("executor")
         self.speak()
         self.cmdloop(self.first_reaction_text)


### PR DESCRIPTION
I did not think it was necessary to require the keyword "calculate" or "evaluate" to begin a mathematical expression. I changed this so that "4 + 5" can be directly entered to the jarvis terminal and have the sum computed. All I changed was that a leading digit or "-" (negative) has "calculate" appended to the front of the statement to be processed as a standard "calculate" function.