### PR TITLE
Fixed do_wiki

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -773,6 +773,7 @@ class CmdInterpreter(Cmd):
     def do_wiki(self, s):
         """Jarvis will get wiki details for you"""
         k = s.split(' ', 1)
+        data = None
         if k[0] == "search":
             data = wiki.search(" ".join(k[1:]))
         elif k[0] == "summary":


### PR DESCRIPTION
the do_wiki function throws an exception when you call it without arguments