### PR TITLE
Add mute feature

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -80,6 +80,7 @@ class CmdInterpreter(Cmd):
                         {"movie": ("cast", "director", "plot", "producer", "rating", "year",)},
                         "movies",
                         "music",
+                        "mute",
                         "near",
                         "news",
                         {"open": ("camera",)},
@@ -794,3 +795,14 @@ class CmdInterpreter(Cmd):
         print_say("enter wiki search for searching related topics", self)
         print_say("enter wiki summary for getting summary of the topic", self)
         print_say("wiki content for full page article of topic", self)
+
+    def do_mute(self, s):
+        """Silences your speaker's sound."""
+        if IS_MACOS:
+            pass
+        else:
+            system("pactl -- set-sink-mute 0 toggle")
+
+    def help_mute(self):
+        """Print help about mute command."""
+        print_say("mute: Silences your speaker's sound.", self)


### PR DESCRIPTION
I added a mute feature, the Linux part is all set, but I don't currently have access to a Mac OS and need some help on that front. Currently the mute command will toggle the sound on or off depending on the state  your sound device is in when you call it, would it be better to have two commands instead (mute and unmute) since that's more natural for people operating Jarvis by voice command?