### PR TITLE
Added macos support for file_organise and help text for lyrics command

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -452,6 +452,8 @@ class CmdInterpreter(Cmd):
         print_say("finds lyrics\n", self)
         print_say("the format is song,artist\n", self)
         print_say("song and artist are separated by a - \n", self)
+        print_say("-- Example:", self)
+        print_say("\tlyrics wonderful tonight-eric clapton", self)
 
     def do_match(self, s):
         """Matches patterns in a string by using regex."""

--- a/jarviscli/packages/file_organise.py
+++ b/jarviscli/packages/file_organise.py
@@ -6,7 +6,15 @@ import six
 
 def source_path(dir_name):
     all_paths = []
-    for root in os.walk("/home"):
+    # Changing static path to get the home path from PATH variables.
+    # The '/home' was causing script to exit with "file not found" error
+    # on Darwin.
+    home_dir = os.environ.get("HOME")
+    user_name = os.environ.get("USER")
+    home_path = home_dir.split(user_name)[0].rstrip('/')
+    for root in os.walk(home_path):
+        print(Fore.LIGHTBLUE_EX + "Searching in {}...".format((root[0])[:70]), end="\r")
+        sys.stdout.flush()
         if dir_name == root[0].split('/')[-1]:
             all_paths.append(root[0])
 


### PR DESCRIPTION
- Added support for mac os in file_organise command; file_organise command exited with error "file not found" because it was looking in '/home' dir which is linux only path.
- Added example in help text for lyrics since it was not very clear as to how to use it.