### PR TITLE
Error checks in do_wiki() function for "wiki" command.

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -927,7 +927,17 @@ class CmdInterpreter(Cmd):
 
     def do_wiki(self, s):
         """Jarvis will get wiki details for you"""
+
+        # if no input or False values after 'wiki' command, return.
+        if not s:
+            return
         k = s.split(' ', 1)
+        # check for index at 1.
+        try:
+            k[1]
+        except IndexError:
+            self.error()
+            return
         data = None
         if k[0] == "search":
             data = wiki.search(" ".join(k[1:]))


### PR DESCRIPTION
 The command wiki was crashing after supplying no arguments to "wiki"
command. Also since wiki command always needs arguments after it's first arg, checked for index at 1.