### PR TITLE
Capitalize 'i' in line 277 in plugin.py. 

### DIFF
--- a/jarviscli/plugin.py
+++ b/jarviscli/plugin.py
@@ -274,4 +274,4 @@ class PluginComposed(object):
             self._command_fallback.run(jarvis, s)
             return
 
-        jarvis.say("Sorry, i don't know what you mean...")
+        jarvis.say("Sorry, I don't know what you mean...")


### PR DESCRIPTION
Capitalize 'i' in line 277 in plugin.py to adhere to English grammar standards.