### PR TITLE
Moved from deprecated freegeoip.net api to api.ipstack.com/check in g…

### DIFF
--- a/jarviscli/packages/mapps.py
+++ b/jarviscli/packages/mapps.py
@@ -11,7 +11,7 @@ def get_location():
     global location
     if not location:
         print("Getting Location ... ")
-        send_url = 'http://freegeoip.net/json'
+        send_url = 'http://api.ipstack.com/check?access_key=8f7b2ef26a8f5e88eb25ae02606284c2&output=json&legacy=1'
         r = requests.get(send_url)
         location = json.loads(r.text)
     return location


### PR DESCRIPTION
as Identified in https://github.com/sukeesh/Jarvis/issues/329 users were unable to check weather (and presumably do other things that used mapps.get_location) as the api mapps.get_location was using is deprecated. This pull request fixes this by using the http://api.ipstack.com/check api instead (The suggested replacement for the api). I opted to use the legacy query string to keep the result consistent, however we may to consider using the updated API. I'm using my own API key (free to create). If you would be more comfortable using your own API key, you can create your own at https://ipstack.com/ and update the code yourself using that key and then scrape this pull request.