### PR TITLE
Added error message for no cricket matches being played

### DIFF
--- a/jarviscli/plugins/cricket.py
+++ b/jarviscli/plugins/cricket.py
@@ -115,6 +115,9 @@ class Cricket(Plugin):
     def score(self, jarvis):
         matches = self.all_matches()
         jarvis.say(Fore.RED + "\nALL MATCHES\n" + Fore.LIGHTBLUE_EX)
+        if matches == []:
+            jarvis.say(Fore.BLACK + "No Matches Being Played!\n" + Fore.RESET)
+            return
         for i, m in enumerate(matches, 1):
             jarvis.say("{}. {}".format(str(i), m))
         choice = int(input(Fore.RED + '\nEnter choice (number): ' + Fore.RESET))

--- a/jarviscli/plugins/cricket.py
+++ b/jarviscli/plugins/cricket.py
@@ -116,7 +116,7 @@ class Cricket(Plugin):
         matches = self.all_matches()
         jarvis.say(Fore.RED + "\nALL MATCHES\n" + Fore.LIGHTBLUE_EX)
         if matches == []:
-            jarvis.say(Fore.BLACK + "No Matches Being Played!\n" + Fore.RESET)
+            jarvis.say("No Matches Being Played!\n", Fore.RED)
             return
         for i, m in enumerate(matches, 1):
             jarvis.say("{}. {}".format(str(i), m))


### PR DESCRIPTION
Creating new pull request because the earlier one shows travis ci build failed. If it still fails the build check please let me know the reason for the failure because i am quite new to all this.

Earlier, when the pycricbuzz library was returning an empty list of cricket games, jarvis was stuck in an infinite loop requesting for a choice. Now an error message of "No Matches Being Played!" has been added and the control returns immediately from the respective function when such a situation occurs. This change improves user experience.