### PR TITLE
Using gmail from the cli using SMTP

### DIFF
--- a/jarviscli/plugins/cricket.py
+++ b/jarviscli/plugins/cricket.py
@@ -116,7 +116,7 @@ class Cricket(Plugin):
         matches = self.all_matches()
         jarvis.say(Fore.RED + "\nALL MATCHES\n" + Fore.LIGHTBLUE_EX)
         if matches == []:
-            jarvis.say(Fore.BLACK + "No Matches Being Played!\n" + Fore.RESET)
+            jarvis.say("No Matches Being Played!\n", Fore.RED)
             return
         for i, m in enumerate(matches, 1):
             jarvis.say("{}. {}".format(str(i), m))

--- a/jarviscli/plugins/gmail.py
+++ b/jarviscli/plugins/gmail.py
@@ -27,7 +27,8 @@ def gmail(jarvis, s):
         print("User Logged in")
     except:
         print('''Allow Less secure apps in GOOGLE ACCOUNT SETTINGS to use SMTP services by following the given steps: 
-										\n\t\tStep 1. Log in to email using your browser. 											\n\t\tStep 2. Go to account settings.
+										\n\t\tStep 1. Log in to email using your browser. 
+										\n\t\tStep 2. Go to account settings.
 										\n\t\tStep 3. Find 'allow less secure apps' and mark it as ON.''')  											         
         server.quit()
         exit()

--- a/jarviscli/plugins/gmail.py
+++ b/jarviscli/plugins/gmail.py
@@ -1,49 +1,40 @@
-from plugin import plugin 				#import plugin
-import smtplib                                      	#import stmplib
+from plugin import plugin 					# import plugin
+import smtplib                                      		# import stmplib
 
-@plugin()						    	#decorator
+
+@plugin()						    	# decorator
 def gmail(jarvis, s):
     '''
     Sending email from a gmail account using SMTP services.
     To use this plugin :
-		1. User should have a gmail id.
-		2. Less secure apps should be allowed to access the gmail account.		
+                1. User should have a gmail id.
+                2. Less secure apps should be allowed to access the gmail account.
     '''
-    try:                
-        server = smtplib.SMTP("smtp.gmail.com", 587)    #establshing server connection
+    try:
+        server = smtplib.SMTP("smtp.gmail.com", 587)   		 # establshing server connection
         server.ehlo()
         server.starttls()
         print("SERVER CONNECTED")
     except:
-        print("Could Not connect to Gmail")             #in case of failure
-
-    user = input("Enter User id\n")                     #YOUR ID
-    Pass_w = input("\nEnter your Password\n")           #YOUR Password
-    reciever_id = input("\nEnter reciever id\n")        #Reciever ID
-    msg = input("\nEnter message\n")                    #message
+        print("Could Not connect to Gmail")            		 # in case of failure
+        exit()
+    user = input("Enter User id\n")                     	 # YOUR ID
+    Pass_w = input("\nEnter your Password\n")           	 # YOUR Password
+    reciever_id = input("\nEnter reciever id\n")        	 # Reciever ID
+    msg = input("\nEnter message\n")                    	 # message
 
     try:
-        server.login(user, Pass_w)                      #user log in
+        server.login(user, Pass_w)                      	 # user log in
         print("User Logged in")
     except:
-        print('''Allow Less secure apps in GOOGLE ACCOUNT SETTINGS to use SMTP services by following the given steps: 
-										\n\t\tStep 1. Log in to email using your browser. 
-										\n\t\tStep 2. Go to account settings.
-										\n\t\tStep 3. Find 'allow less secure apps' and mark it as ON.''')  											         
+        print('''Allow Less secure apps in GOOGLE ACCOUNT SETTINGS to use SMTP services by following the given steps:
+                                                                      \n\t\tStep 1. Log in to email using your browser.
+                                                                      \n\t\tStep 2. Go to account settings.
+                                                                      \n\t\tStep 3. Find 'allow less secure apps' and mark it as ON.''')
         server.quit()
         exit()
-
     server.sendmail(user, reciever_id, msg)
-    print("MAIL sent")                                  #confirmation
-
-
+    print("MAIL sent")                                  	 # confirmation
     print("Closing Connection")
-    server.quit()                                       #closing server connection
+    server.quit()                                       	 # closing server connection
     print("Server closed")
-
-
-
-
-
-
-


### PR DESCRIPTION
To use SMTP services :
1. User should have a gmail id. 
2. Less secure apps should be allowed to acces the email.

To allow Less secure apps to acces the user's email id:
Step 1. Log in to email using your browser. 
Step 2. Go to account settings. 
Step 3. Find 'allow less secure apps' and mark it as ON.

To use the plugin, after launching Jarvis, give the command **gmail**.