### PR TITLE
update curl command to use --connect-timeout

### DIFF
--- a/jarviscli/plugins/clear.py
+++ b/jarviscli/plugins/clear.py
@@ -4,6 +4,6 @@ import os
 
 
 @plugin()
-def clear():
+def clear(jarvis, s):
     """Clears terminal"""
     os.system("clear")

--- a/jarviscli/plugins/ip.py
+++ b/jarviscli/plugins/ip.py
@@ -13,8 +13,8 @@ class IP(Plugin):
         self._local_ip = """ifconfig | grep -Eo 'inet (addr:)?([0-9]*\\.){3}[0-9]*' |
                     grep -Eo '([0-9]*\\.){3}[0-9]*' | grep -v '127.0.0.1'"""
 
-        self._public_ip_v4 = "timeout 10 curl -4 ifconfig.co"  # 10 second time out if not connected to internet
-        self._public_ip_v6 = "timeout 10 curl -6 ifconfig.co"  # 10 second time out if not connected to internet
+        self._public_ip_v4 = "curl -4 ifconfig.co --connect-timeout 10"  # 10 second time out if not connected to internet
+        self._public_ip_v6 = "curl -6 ifconfig.co --connect-timeout 10"  # 10 second time out if not connected to internet
         super(Plugin, self).__init__()
 
     def require(self):
@@ -38,5 +38,5 @@ class IP(Plugin):
     def _get_public_ip(self, jarvis):
         jarvis.say("Public ip v4 address :", Fore.BLUE)
         system(self._public_ip_v4)
-        jarvis.say("Public ip v4 address :", Fore.BLUE)
+        jarvis.say("Public ip v6 address :", Fore.BLUE)
         system(self._public_ip_v6)


### PR DESCRIPTION
- update curl command to use --connect-timeout option instead of timeout command. closes 
[#390](https://github.com/sukeesh/Jarvis/issues/390)
- fix typo in file [ip.py]()
Public ip v4 address -> Public ip v6 address
- fix clear plugin issue [#392](https://github.com/sukeesh/Jarvis/issues/392)