### PR TITLE
Enhanced output of os plugin on macOS

### DIFF
--- a/jarviscli/plugins/systemOptions.py
+++ b/jarviscli/plugins/systemOptions.py
@@ -1,9 +1,7 @@
 import os
-from platform import architecture, dist, release
+from platform import architecture, dist, release, mac_ver
 from platform import system as sys
-
-from colorama import Fore
-
+from colorama import Fore, Style
 from plugin import LINUX, MACOS, PYTHON2, PYTHON3, plugin
 
 
@@ -19,8 +17,20 @@ def screen_off__LINUX(jarvis, s):
     os.system('xset dpms force off')
 
 
-@plugin()
-def Os(jarvis, s):
+@plugin(plattform=MACOS)
+def Os__MAC(jarvis, s):
+    """Displays information about your operating system"""
+    jarvis.say(Style.BRIGHT + '[!] Operating System Information' + Style.RESET_ALL, Fore.BLUE)
+    jarvis.say('[*] Kernel: ' + sys(), Fore.GREEN)
+    jarvis.say('[*] Kernel Release Version: ' + release(), Fore.GREEN)
+    jarvis.say('[*] macOS System version: ' + mac_ver()[0], Fore.GREEN)
+    for _ in architecture():
+        if _ is not '':
+            jarvis.say('[*] ' + _, Fore.GREEN)
+
+
+@plugin(plattform=LINUX)
+def Os__LINUX(jarvis, s):
     """Displays information about your operating system"""
     jarvis.say('[!] Operating System Information', Fore.BLUE)
     jarvis.say('[*] ' + sys(), Fore.GREEN)


### PR DESCRIPTION
Before:
<img width="348" alt="screenshot 2019-01-19 at 8 12 10 pm" src="https://user-images.githubusercontent.com/6890568/51428186-c3c03780-1c26-11e9-8fd4-6b9e2c5a8f9c.png">

After:
<img width="348" alt="screenshot 2019-01-19 at 8 07 04 pm" src="https://user-images.githubusercontent.com/6890568/51428113-151bf700-1c26-11e9-8c11-2ebdfbb7c183.png">

