### PR TITLE
Fix news plugin for bugs

### DIFF
--- a/jarviscli/plugins/news.py
+++ b/jarviscli/plugins/news.py
@@ -252,7 +252,7 @@ class News():
         # check if we have a valid index
         try:
             int(idx)
-            if int(idx) > index-1:
+            if int(idx) > index - 1:
                 print("Not a valid index")
                 return
             elif int(idx) == 0:

--- a/jarviscli/plugins/news.py
+++ b/jarviscli/plugins/news.py
@@ -227,11 +227,12 @@ class News():
         except AttributeError:
             response = urllib.urlopen(url)
         # Load json
-        data = json.loads(response.read())
+        data = json.loads(response.read().decode('utf-8'))
         article_list = {}
         index = 1
         # print articles with their index
         print("Top News Articles from " + self.source)
+        print("0: Exit/Quit")
         for article in data['articles']:
             # print (Fore.GREEN + str(index) + ": " + article['title'] + Fore.RESET)
             print(str(index) + ": " + article['title'])
@@ -251,8 +252,10 @@ class News():
         # check if we have a valid index
         try:
             int(idx)
-            if int(idx) > index:
+            if int(idx) > index-1:
                 print("Not a valid index")
+                return
+            elif int(idx) == 0:
                 return
         except:
             print("Not a valid index")


### PR DESCRIPTION
1. urllib.urlopen return bytes. Response should be decded to utf-8 before loading into json format.

Example(failing case):
madhav@ubuntu:~/Projects/Jarvis$ ./jarvis
Jarvis' sound is by default disabled.
In order to let Jarvis talk out loud type: enable sound
Type 'help' for a list of available actions.
84 plugins loaded 6 plugins disabled. More information: status

~> Hi, what can I do for you?
news
Would you like to configure your own news channel(y/n)
y
I couldn't find news
~> What can i do for you?
news
Would you like to configure your own news channel(y/n)
n
Select Source (1-5):
1: BBC
2: BUZZFEED
3: Google
4: Reddit
5: TechCrunch
1
would you like to set this as your default? (yes/no):
yes
I couldn't find news
~> What can i do for you?

SOLVED WITH THE COMMITr[(added decode('utf-8')]

2. Cover corner cases while taking user input via message "Type index to expand news". Corner cases 0 and (for example) 11 do not work as expected.
made 0 as an option for Exit/Quit. If user inputs index+1(ex: 11 below), reply with "Not valid index"

Example(failing cases):
~> What can i do for you?
news
Would you like to configure your own news channel(y/n)
n
your default news source is bbc-news
Would you like news from this source? (yes/no):
yes
Top News Articles from bbc-news
1: US Congress awaits Mueller report findings
2: May urged to quit to help deal pass
3: Passengers evacuated from Norway cruise
4: More bodies under Cyclone Idai floods - UN
5: Huge fossil discovery made in China
6: Trump vows to 'crush' remaining IS cells
7: Thailand votes in first post-coup election
8: Protests over acquittal in police shooting
9: Streisand criticised for Jackson comments
10: Mossad spy who captured Eichmann dies
Powered by News API. Type NewsAPI to learn more
Type index to expand news

0
I couldn't find news
~> What can i do for you?

--------------------
~> What can i do for you?
news
Would you like to configure your own news channel(y/n)
n
your default news source is bbc-news
Would you like news from this source? (yes/no):
yes
Top News Articles from bbc-news
0: Exit/Quit
1: US Congress awaits Mueller report findings
2: May urged to quit to help deal pass
3: Passengers evacuated from Norway cruise
4: More bodies under Cyclone Idai floods - UN
5: Huge fossil discovery made in China
6: Trump vows to 'crush' remaining IS cells
7: Thailand votes in first post-coup election
8: Protests over acquittal in police shooting
9: Streisand criticised for Jackson comments
10: Mossad spy who captured Eichmann dies
Powered by News API. Type NewsAPI to learn more
Type index to expand news

11
I couldn't find news
~> What can i do for you?