### PR TITLE
Write agenda plugin v0.1

### DIFF
--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -2,8 +2,8 @@ from plugin import plugin
 import csv
 
 
-@plugin("write_agenda")
-def agenda(jarvis, s):
+@plugin("write agenda")
+def write_agenda(jarvis, s):
     exit = True
     csv_columns = ['Title', 'Description']
     mydict = {}
@@ -28,3 +28,14 @@ def agenda(jarvis, s):
             print("I/O error")
     else:
         print('Nothing for the agenda')
+
+@plugin("read agenda")
+def read_agenda(jarvis, s):
+    try:
+        f = open('agenda.csv', 'r')
+        reader = csv.reader(f)
+        for row in reader:
+            print (row)
+        f.close()
+    except:
+        print('There is not an agenda')

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -29,7 +29,7 @@ def write_agenda(jarvis, s):
     else:
         print('Nothing for the agenda')
 
-        
+
 @plugin("read agenda")
 def read_agenda(jarvis, s):
     try:

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -25,6 +25,6 @@ def agenda(jarvis, s):
                 for key, value in mydict.items():
                     writer.writerow([key, value])
         except IOError:
-            print("I/O error") 
+            print("I/O error")
     else:
         print('Nothing for the agenda')

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -7,7 +7,7 @@ def agenda(jarvis, s):
     csv_columns = ['Title','Description']
     mydict = {}
 
-    while(exit==False):
+    while(exit == False):
         event_title = input("Write down the event title: ")
         event_description = input("Write down the event description: ")
         event_option = input("Anything more?(y/n): ")

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -1,10 +1,11 @@
 from plugin import plugin
 import csv
 
+
 @plugin("write_agenda")
 def agenda(jarvis, s):
     exit = False
-    csv_columns = ['Title','Description']
+    csv_columns = ['Title', 'Description']
     mydict = {}
 
     while(exit == False):
@@ -19,7 +20,7 @@ def agenda(jarvis, s):
     if bool(mydict):
         print('New inputs are: ' + str(mydict))
         try:
-            with open('agenda.csv','w') as csv_file:
+            with open('agenda.csv', 'w') as csv_file:
                 writer = csv.writer(csv_file)
                 for key, value in mydict.items():
                     writer.writerow([key, value])

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -2,7 +2,7 @@ from plugin import plugin
 import csv
 
 
-@plugin("write agenda")
+@plugin("write_agenda")
 def agenda(jarvis, s):
     exit = True
     csv_columns = ['Title', 'Description']

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -13,8 +13,8 @@ def agenda(jarvis, s):
         event_option = input("Anything more?(y/n): ")
         mydict[event_title] = event_description
 
-        if(event_option =='n'):
-            exit=True
+        if(event_option == 'n'):
+            exit = True
 
     if bool(mydict):
         print('New inputs are: ' + str(mydict))

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -4,18 +4,18 @@ import csv
 
 @plugin("write agenda")
 def agenda(jarvis, s):
-    exit = False
+    exit = True
     csv_columns = ['Title', 'Description']
     mydict = {}
 
-    while(exit == False):
+    while(exit):
         event_title = input("Write down the event title: ")
         event_description = input("Write down the event description: ")
         event_option = input("Anything more?(y/n): ")
         mydict[event_title] = event_description
 
         if(event_option == 'n'):
-            exit = True
+            exit = False
 
     if bool(mydict):
         print('New inputs are: ' + str(mydict))

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -1,0 +1,29 @@
+from plugin import plugin
+import csv
+
+@plugin("write_agenda")
+def agenda(jarvis, s):
+    exit = False
+    csv_columns = ['Title','Description']
+    mydict = {}
+
+    while(exit==False):
+        event_title = input("Write down the event title: ")
+        event_description = input("Write down the event description: ")
+        event_option = input("Anything more?(y/n): ")
+        mydict[event_title] = event_description
+
+        if(event_option =='n'):
+            exit=True
+
+    if bool(mydict):
+        print('New inputs are: ' + str(mydict))
+        try:
+            with open('agenda.csv','w') as csv_file:
+                writer = csv.writer(csv_file)
+                for key, value in mydict.items():
+                    writer.writerow([key, value])
+        except IOError:
+            print("I/O error") 
+    else:
+        print('Nothing for the agenda')

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -2,7 +2,7 @@ from plugin import plugin
 import csv
 
 
-@plugin("write_agenda")
+@plugin("write agenda")
 def agenda(jarvis, s):
     exit = False
     csv_columns = ['Title', 'Description']

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -29,13 +29,14 @@ def write_agenda(jarvis, s):
     else:
         print('Nothing for the agenda')
 
+        
 @plugin("read agenda")
 def read_agenda(jarvis, s):
     try:
         f = open('agenda.csv', 'r')
         reader = csv.reader(f)
         for row in reader:
-            print (row)
+            print(row)
         f.close()
     except:
         print('There is not an agenda')


### PR DESCRIPTION
A little script that allows the user to write key:value data in a CSV. This is the entry point for a Read_agenda plugin that recovers these data and future improves like a  reminder of events ,bearing in mind the dead line that they will have. For the next version Write_agenda will allow to add new lines to your agenda, at this moment every time you execute the script it will overwrite the old agenda with the new data