### PR TITLE
[format] use autopep8 to format Python code to PEP 8 style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
     fi
 script:
   - cd $TRAVIS_BUILD_DIR/
-  - flake8 --select E,W --max-line-length=140 --ignore E722 jarviscli/
+  - flake8 --select E,W --max-line-length=140 --ignore E722,W503,W504 jarviscli/
   - cd jarviscli/
   - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TOXENV" == "py27" ]; then
       python2 -m unittest discover;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
     fi
 script:
   - cd $TRAVIS_BUILD_DIR/
-  - flake8 --select E,W --max-line-length=140 --ignore E722,W503,W504 jarviscli/
+  - flake8 --select E,W --max-line-length=140 --ignore E722,W503,W504,E128 jarviscli/
   - cd jarviscli/
   - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TOXENV" == "py27" ]; then
       python2 -m unittest discover;

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ build_docker:
 run_docker:
 	#Needs "xhost local:docker"
 	docker run -it --rm -e DISPLAY=${DISPLAY} -v /tmp/.X11-unix:/tmp/.X11-unix jarvis:$(VERSION)
+
+autopep8:
+    @find . -iname "*.py" -not -path "./env/**" | xargs autopep8 --in-place --aggressive --aggressive
+    

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,3 @@ run_docker:
 
 autopep8:
     @find . -iname "*.py" -not -path "./env/**" | xargs autopep8 --in-place --aggressive --aggressive
-    

--- a/installpyaudio.py
+++ b/installpyaudio.py
@@ -7,12 +7,27 @@ from six.moves import input
 
 install_command = None
 if platform.system().lower() == "linux":
-    pm = {'redhat': ('sudo yum install', ('python2-pyaudio', 'python3-pyaudio')),
-          'arch': ('sudo packman -S', ('python2-pyaudio', 'python-pyaudio')),
-          'gentoo': ('sudo emerge --ask --verbose', ('pyaudio', 'pyaudio')),
-          'suse': ('sudo zypper install', ('python-PyAudio', 'python3-PyAudio')),
-          'debian': ('sudo apt-get install', ('python-pyaudio', 'python3-pyaudio'))
-          }
+    pm = {
+        'redhat': (
+            'sudo yum install',
+            ('python2-pyaudio',
+             'python3-pyaudio')),
+        'arch': (
+            'sudo packman -S',
+            ('python2-pyaudio',
+             'python-pyaudio')),
+        'gentoo': (
+            'sudo emerge --ask --verbose',
+            ('pyaudio',
+             'pyaudio')),
+        'suse': (
+            'sudo zypper install',
+            ('python-PyAudio',
+             'python3-PyAudio')),
+        'debian': (
+            'sudo apt-get install',
+            ('python-pyaudio',
+             'python3-pyaudio'))}
 
     distroid = distro.os_release_attr('id_like')
 
@@ -26,7 +41,8 @@ if platform.system().lower() == "linux":
             else:
                 print("Usage: python installpyaudio.py (py2/py3)")
                 sys.exit(1)
-            install_command = "{} {}".format(base_command, packages_names[python_version])
+            install_command = "{} {}".format(
+                base_command, packages_names[python_version])
 elif platform.system().lower() == "darwin":
     install_command = 'brew install portaudio'
 

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -77,7 +77,8 @@ class JarvisAPI(object):
            - *args
         :return: integer, id - use with cancel
         """
-        return self._jarvis.scheduler.create_event(time_seconds, function, self, *args)
+        return self._jarvis.scheduler.create_event(
+            time_seconds, function, self, *args)
 
     def cancel(self, schedule_id):
         """
@@ -152,7 +153,9 @@ def catch_all_exceptions(do, pass_self=True):
             else:
                 do(s)
         except Exception:
-            print(Fore.RED + "Some error occurred, please open an issue on github!")
+            print(
+                Fore.RED +
+                "Some error occurred, please open an issue on github!")
             print("Here is error:")
             print('')
             traceback.print_exc()
@@ -167,7 +170,13 @@ class CmdInterpreter(Cmd):
 
     # This can be used to store user specific data
 
-    def __init__(self, first_reaction_text, prompt, directories=[], first_reaction=True, enable_voice=False):
+    def __init__(
+            self,
+            first_reaction_text,
+            prompt,
+            directories=[],
+            first_reaction=True,
+            enable_voice=False):
         """
         This constructor contains a dictionary with Jarvis Actions (what Jarvis can do).
         In alphabetically order.
@@ -211,7 +220,8 @@ class CmdInterpreter(Cmd):
             plugin_status += " {red}{disabled} {blue}plugins disabled. More information: {red}status\n"
         plugin_status += Fore.RESET
 
-        self.first_reaction_text += plugin_status.format(**plugin_status_formatter)
+        self.first_reaction_text += plugin_status.format(
+            **plugin_status_formatter)
 
     def _activate_plugins(self):
         """Generate do_XXX, help_XXX and (optionally) complete_XXX functions"""
@@ -219,8 +229,19 @@ class CmdInterpreter(Cmd):
             self._plugin_update_completion(plugin, plugin_name)
 
             run_catch = catch_all_exceptions(plugin.run)
-            setattr(CmdInterpreter, "do_" + plugin_name, partial(run_catch, self))
-            setattr(CmdInterpreter, "help_" + plugin_name, partial(self._api.say, plugin.get_doc()))
+            setattr(
+                CmdInterpreter,
+                "do_" +
+                plugin_name,
+                partial(
+                    run_catch,
+                    self))
+            setattr(
+                CmdInterpreter,
+                "help_" + plugin_name,
+                partial(
+                    self._api.say,
+                    plugin.get_doc()))
 
             plugin.init(self._api)
 
@@ -232,7 +253,11 @@ class CmdInterpreter(Cmd):
                 def _complete_impl(self, text, line, begidx, endidx):
                     return [i for i in completions if i.startswith(text)]
                 return _complete_impl
-            setattr(CmdInterpreter, "complete_" + plugin_name, complete(completions))
+            setattr(
+                CmdInterpreter,
+                "complete_" +
+                plugin_name,
+                complete(completions))
 
     def get_api(self):
         return self._api
@@ -254,7 +279,7 @@ class CmdInterpreter(Cmd):
     def get_completions(self, command, text):
         """Returns a list with the completions of a command."""
         dict_target = [item for item in self.actions
-                       if type(item) == dict and command in item][0]
+                       if isinstance(item, dict) and command in item][0]
         completions_list = dict_target[command]
         return [i for i in completions_list if i.startswith(text) and i != '']
 
@@ -266,13 +291,20 @@ class CmdInterpreter(Cmd):
         """Prints plugin status status"""
         count_enabled = self._plugin_manager.get_number_plugins_loaded()
         count_disabled = len(self._plugin_manager.get_disabled())
-        print_say("{} Plugins enabled, {} Plugins disabled.".format(count_enabled, count_disabled),
-                  self)
+        print_say(
+            "{} Plugins enabled, {} Plugins disabled.".format(
+                count_enabled,
+                count_disabled),
+            self)
 
         if "short" not in s and count_disabled > 0:
             print_say("", self)
             for disabled, reason in self._plugin_manager.get_disabled().items():
-                print_say("{:<20}: {}".format(disabled, "OR ".join(reason)), self)
+                print_say(
+                    "{:<20}: {}".format(
+                        disabled,
+                        "OR ".join(reason)),
+                    self)
 
     def help_status(self):
         print_say("Prints info about enabled or disabled plugins", self)

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -154,8 +154,8 @@ def catch_all_exceptions(do, pass_self=True):
                 do(s)
         except Exception:
             print(
-                Fore.RED +
-                "Some error occurred, please open an issue on github!")
+                Fore.RED
+                + "Some error occurred, please open an issue on github!")
             print("Here is error:")
             print('')
             traceback.print_exc()
@@ -231,8 +231,8 @@ class CmdInterpreter(Cmd):
             run_catch = catch_all_exceptions(plugin.run)
             setattr(
                 CmdInterpreter,
-                "do_" +
-                plugin_name,
+                "do_"
+                + plugin_name,
                 partial(
                     run_catch,
                     self))
@@ -255,8 +255,8 @@ class CmdInterpreter(Cmd):
                 return _complete_impl
             setattr(
                 CmdInterpreter,
-                "complete_" +
-                plugin_name,
+                "complete_"
+                + plugin_name,
                 complete(completions))
 
     def get_api(self):

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -38,9 +38,9 @@ class Jarvis(CmdInterpreter, object):
         "Type 'help' for a list of available actions." + Fore.RESET
     first_reaction_text += "\n"
     prompt = (
-        Fore.RED +
-        "{} Hi, what can I do for you?\n".format(PROMPT_CHAR) +
-        Fore.RESET)
+        Fore.RED
+        + "{} Hi, what can I do for you?\n".format(PROMPT_CHAR)
+        + Fore.RESET)
 
     # This can be used to store user specific data
 
@@ -96,9 +96,9 @@ class Jarvis(CmdInterpreter, object):
         """Hook that executes after every command."""
         if self.first_reaction:
             self.prompt = (
-                Fore.RED +
-                "{} What can i do for you?\n".format(PROMPT_CHAR) +
-                Fore.RESET)
+                Fore.RED
+                + "{} What can i do for you?\n".format(PROMPT_CHAR)
+                + Fore.RESET)
             self.first_reaction = False
         if self.enable_voice:
             self.speech.text_to_speech("What can i do for you?\n")

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -38,8 +38,9 @@ class Jarvis(CmdInterpreter, object):
         "Type 'help' for a list of available actions." + Fore.RESET
     first_reaction_text += "\n"
     prompt = (
-        Fore.RED + "{} Hi, what can I do for you?\n".format(PROMPT_CHAR) + Fore.RESET
-    )
+        Fore.RED +
+        "{} Hi, what can I do for you?\n".format(PROMPT_CHAR) +
+        Fore.RESET)
 
     # This can be used to store user specific data
 
@@ -74,7 +75,8 @@ class Jarvis(CmdInterpreter, object):
         """Hook that executes before every command."""
         words = line.split()
 
-        # append calculate keyword to front of leading char digit (or '-') in line
+        # append calculate keyword to front of leading char digit (or '-') in
+        # line
         if words and (words[0].isdigit() or line[0] == "-"):
             line = "calculate " + line
             words = line.split()
@@ -94,8 +96,9 @@ class Jarvis(CmdInterpreter, object):
         """Hook that executes after every command."""
         if self.first_reaction:
             self.prompt = (
-                Fore.RED + "{} What can i do for you?\n".format(PROMPT_CHAR) + Fore.RESET
-            )
+                Fore.RED +
+                "{} What can i do for you?\n".format(PROMPT_CHAR) +
+                Fore.RESET)
             self.first_reaction = False
         if self.enable_voice:
             self.speech.text_to_speech("What can i do for you?\n")
@@ -121,8 +124,10 @@ class Jarvis(CmdInterpreter, object):
         if data in self.fixed_responses:
             output = self.fixed_responses[data]  # change return to output =
         else:
-            # if it doesn't have a fixed response, look if the data corresponds to an action
-            output = self.find_action(data, self._plugin_manager.get_plugins().keys())
+            # if it doesn't have a fixed response, look if the data corresponds
+            # to an action
+            output = self.find_action(
+                data, self._plugin_manager.get_plugins().keys())
         return output
 
     def find_action(self, data, actions):
@@ -146,7 +151,8 @@ class Jarvis(CmdInterpreter, object):
             words_remaining = data.split()  # this will help us to stop the iteration
             for word in words:
                 words_remaining.remove(word)
-                # For the 'near' keyword, the words before 'near' are also needed
+                # For the 'near' keyword, the words before 'near' are also
+                # needed
                 if word == "near":
                     initial_words = words[:words.index('near')]
                     output = word + " " +\

--- a/jarviscli/PluginManager.py
+++ b/jarviscli/PluginManager.py
@@ -14,6 +14,7 @@ class PluginManager(object):
     https://github.com/benhoff/pluginmanager
     Also handles plugin.PluginComposed
     """
+
     def __init__(self):
         self._backend = pluginmanager.PluginInterface()
         self._plugin_dependency = PluginDependency()
@@ -52,7 +53,8 @@ class PluginManager(object):
         for plugin_to_add in enabled:
             self._load_plugin(plugin_to_add, self._cache)
 
-        self._cache_disabled = self._filter_duplicated_disabled(enabled, disabled)
+        self._cache_disabled = self._filter_duplicated_disabled(
+            enabled, disabled)
         self._plugins_loaded = len(enabled)
 
     def _validate_plugins(self, plugins):
@@ -64,11 +66,14 @@ class PluginManager(object):
                 if not is_plugin(plugin_to_validate):
                     continue
 
-                compability_check_result = self._plugin_dependency.check(plugin_to_validate)
+                compability_check_result = self._plugin_dependency.check(
+                    plugin_to_validate)
                 if compability_check_result is True:
                     plugins_valid.append(plugin_to_validate)
                 else:
-                    item = (plugin_to_validate.get_name(), compability_check_result)
+                    item = (
+                        plugin_to_validate.get_name(),
+                        compability_check_result)
                     plugins_incompatible.append(item)
 
             return (plugins_valid, plugins_incompatible)
@@ -86,10 +91,16 @@ class PluginManager(object):
 
     def _load_plugin(self, plugin_to_add, plugin_storage):
         def handle_aliases(plugin_to_add):
-            add_plugin(plugin_to_add.get_name().split(' '), plugin_to_add, plugin_storage)
+            add_plugin(
+                plugin_to_add.get_name().split(' '),
+                plugin_to_add,
+                plugin_storage)
 
             for name in plugin_to_add.alias():
-                add_plugin(name.lower().split(' '), plugin_to_add, plugin_storage)
+                add_plugin(
+                    name.lower().split(' '),
+                    plugin_to_add,
+                    plugin_storage)
 
         def add_plugin(name, plugin_to_add, parent):
             if len(name) == 1:
@@ -107,7 +118,11 @@ class PluginManager(object):
                 else:
                     error("Duplicated plugin {}!".format(name))
 
-        def add_plugin_compose(name_first, name_remaining, plugin_to_add, parent):
+        def add_plugin_compose(
+                name_first,
+                name_remaining,
+                plugin_to_add,
+                parent):
             plugin_existing = parent.get_plugins(name_first)
 
             if plugin_existing is None:
@@ -263,4 +278,5 @@ class PluginDependency(object):
 
     def _plugin_patch_network_error_message(self, plugin):
         if "plugin._network_error_patched" not in plugin.__dict__:
-            plugin.run = partial(plugin._plugin_run_with_network_error, plugin.run)
+            plugin.run = partial(
+                plugin._plugin_run_with_network_error, plugin.run)

--- a/jarviscli/packages/fileHandler.py
+++ b/jarviscli/packages/fileHandler.py
@@ -23,9 +23,9 @@ def read_file(name, default=None):
                 return json.load(f)
         except ValueError:
             print(
-                Fore.RED +
-                "Storage file not in right format. Backup stored as {0}.bak".format(name) +
-                Fore.RESET)
+                Fore.RED
+                + "Storage file not in right format. Backup stored as {0}.bak".format(name)
+                + Fore.RESET)
             os.rename(name, name + ".bak")
     return default
 

--- a/jarviscli/packages/fileHandler.py
+++ b/jarviscli/packages/fileHandler.py
@@ -23,7 +23,9 @@ def read_file(name, default=None):
                 return json.load(f)
         except ValueError:
             print(
-                Fore.RED + "Storage file not in right format. Backup stored as {0}.bak".format(name) + Fore.RESET)
+                Fore.RED +
+                "Storage file not in right format. Backup stored as {0}.bak".format(name) +
+                Fore.RESET)
             os.rename(name, name + ".bak")
     return default
 

--- a/jarviscli/packages/memory/memory.py
+++ b/jarviscli/packages/memory/memory.py
@@ -20,7 +20,8 @@ example:
     m.add_data('lastName', 'albert')
     m.save()
 '''
-# this sets the path to the modules directory not the directory it was call from
+# this sets the path to the modules directory not the directory it was
+# call from
 module_path = os.path.dirname(__file__)
 
 
@@ -58,7 +59,7 @@ class Memory:
     def get_data(self, key):
         try:
             return self.data[key]
-        except:
+        except BaseException:
             return None
 
     '''

--- a/jarviscli/packages/timeIn.py
+++ b/jarviscli/packages/timeIn.py
@@ -5,7 +5,8 @@ import json
 import requests
 from colorama import Fore
 
-# this sets the path to the modules directory not the directory it was call from
+# this sets the path to the modules directory not the directory it was
+# call from
 module_path = os.path.dirname(__file__)
 module_path = module_path + '/../data/'
 
@@ -16,9 +17,18 @@ def main(self, s):
 
     exists = os.path.isfile(module_path + 'key_timein.json')
     if not exists:
-        shutil.copy2(module_path + 'samplekey_timein.json', module_path + 'key_timein.json')
-        print(Fore.RED + "Generate api key here: https://developers.google.com/maps/documentation/geocoding/start?hl=en_US")
-        print(Fore.RED + "and add it to jarviscli/data/key_timein.json" + Fore.RESET)
+        shutil.copy2(
+            module_path +
+            'samplekey_timein.json',
+            module_path +
+            'key_timein.json')
+        print(
+            Fore.RED +
+            "Generate api key here: https://developers.google.com/maps/documentation/geocoding/start?hl=en_US")
+        print(
+            Fore.RED +
+            "and add it to jarviscli/data/key_timein.json" +
+            Fore.RESET)
         return
 
     # Transforms a city name into coordinates using Google Maps API
@@ -47,11 +57,17 @@ def getLocation(s):
         data = json.load(json_file)
     if 'timein' not in data or data['timein'] == 'insertyourkeyhere':
         print(Fore.RED + "API key not added")
-        print(Fore.RED + "Generate api key here: https://developers.google.com/maps/documentation/geocoding/start?hl=en_US")
-        print(Fore.RED + "and add it to jarviscli/data/key_timein.json" + Fore.RESET)
+        print(
+            Fore.RED +
+            "Generate api key here: https://developers.google.com/maps/documentation/geocoding/start?hl=en_US")
+        print(
+            Fore.RED +
+            "and add it to jarviscli/data/key_timein.json" +
+            Fore.RESET)
         return None
     key = data['timein']
-    send_url = ("https://maps.googleapis.com/maps/api/geocode/json?address={0}&key={1}".format(s, key))
+    send_url = (
+        "https://maps.googleapis.com/maps/api/geocode/json?address={0}&key={1}".format(s, key))
     # https://developers.google.com/maps/documentation/geocoding/start?hl=en_US
     # https://maps.googleapis.com/maps/api/geocode/json?address=1600+Amphitheatre+Parkway,+Mountain+View,+CA&key=YOUR_API_KEY
     r = requests.get(send_url)

--- a/jarviscli/packages/timeIn.py
+++ b/jarviscli/packages/timeIn.py
@@ -18,17 +18,17 @@ def main(self, s):
     exists = os.path.isfile(module_path + 'key_timein.json')
     if not exists:
         shutil.copy2(
-            module_path +
-            'samplekey_timein.json',
-            module_path +
-            'key_timein.json')
+            module_path
+            + 'samplekey_timein.json',
+            module_path
+            + 'key_timein.json')
         print(
-            Fore.RED +
-            "Generate api key here: https://developers.google.com/maps/documentation/geocoding/start?hl=en_US")
+            Fore.RED
+            + "Generate api key here: https://developers.google.com/maps/documentation/geocoding/start?hl=en_US")
         print(
-            Fore.RED +
-            "and add it to jarviscli/data/key_timein.json" +
-            Fore.RESET)
+            Fore.RED
+            + "and add it to jarviscli/data/key_timein.json"
+            + Fore.RESET)
         return
 
     # Transforms a city name into coordinates using Google Maps API
@@ -58,12 +58,12 @@ def getLocation(s):
     if 'timein' not in data or data['timein'] == 'insertyourkeyhere':
         print(Fore.RED + "API key not added")
         print(
-            Fore.RED +
-            "Generate api key here: https://developers.google.com/maps/documentation/geocoding/start?hl=en_US")
+            Fore.RED
+            + "Generate api key here: https://developers.google.com/maps/documentation/geocoding/start?hl=en_US")
         print(
-            Fore.RED +
-            "and add it to jarviscli/data/key_timein.json" +
-            Fore.RESET)
+            Fore.RED
+            + "and add it to jarviscli/data/key_timein.json"
+            + Fore.RESET)
         return None
     key = data['timein']
     send_url = (

--- a/jarviscli/packages/umbrella.py
+++ b/jarviscli/packages/umbrella.py
@@ -14,16 +14,16 @@ def main(city=0):
     rain = j['list'][0]['weather'][0]['id']
     if rain >= 300 and rain <= 500:  # In case of drizzle or light rain
         print(
-            Fore.CYAN +
-            "It appears that you might need an umbrella today." +
-            Fore.RESET)
+            Fore.CYAN
+            + "It appears that you might need an umbrella today."
+            + Fore.RESET)
     elif rain > 700:
         print(
-            Fore.CYAN +
-            "Good news! You can leave your umbrella at home for today!" +
-            Fore.RESET)
+            Fore.CYAN
+            + "Good news! You can leave your umbrella at home for today!"
+            + Fore.RESET)
     else:
         print(
-            Fore.CYAN +
-            "Uhh, bad luck! If you go outside, take your umbrella with you." +
-            Fore.RESET)
+            Fore.CYAN
+            + "Uhh, bad luck! If you go outside, take your umbrella with you."
+            + Fore.RESET)

--- a/jarviscli/packages/umbrella.py
+++ b/jarviscli/packages/umbrella.py
@@ -13,8 +13,17 @@ def main(city=0):
     j = json.loads(r.text)
     rain = j['list'][0]['weather'][0]['id']
     if rain >= 300 and rain <= 500:  # In case of drizzle or light rain
-        print(Fore.CYAN + "It appears that you might need an umbrella today." + Fore.RESET)
+        print(
+            Fore.CYAN +
+            "It appears that you might need an umbrella today." +
+            Fore.RESET)
     elif rain > 700:
-        print(Fore.CYAN + "Good news! You can leave your umbrella at home for today!" + Fore.RESET)
+        print(
+            Fore.CYAN +
+            "Good news! You can leave your umbrella at home for today!" +
+            Fore.RESET)
     else:
-        print(Fore.CYAN + "Uhh, bad luck! If you go outside, take your umbrella with you." + Fore.RESET)
+        print(
+            Fore.CYAN +
+            "Uhh, bad luck! If you go outside, take your umbrella with you." +
+            Fore.RESET)

--- a/jarviscli/packages/weatherIn.py
+++ b/jarviscli/packages/weatherIn.py
@@ -9,7 +9,13 @@ from colorama import Fore
 
 def main(self, s):
     # Trim input command to get only the location
-    loc = s.replace('weather', '').replace('in ', '').replace('at ', '').strip()
+    loc = s.replace(
+        'weather',
+        '').replace(
+        'in ',
+        '').replace(
+            'at ',
+        '').strip()
 
     # Checks country
     country = mapps.get_location()['country_name']
@@ -33,7 +39,9 @@ def main(self, s):
     r = requests.get(send_url)
     j = json.loads(r.text)
 
-    if 'message' in list(j.keys()) and ('city not found' in j['message'] or 'Nothing to geocode' in j['message']):
+    if 'message' in list(
+            j.keys()) and (
+            'city not found' in j['message'] or 'Nothing to geocode' in j['message']):
         print("Location invalid. Please be more specific")
         return pinpoint.main(Memory(), self, s)
 

--- a/jarviscli/packages/weather_pinpoint.py
+++ b/jarviscli/packages/weather_pinpoint.py
@@ -28,15 +28,17 @@ def main(memory, self, s):
         loc = str(location)
         city = mapps.get_location()['city']
         if city != loc:
-            print_say("It appears you are in {CITY}. But you set your location to {LOC}"
-                      .format(CITY=city, LOC=loc), self, Fore.RED)
+            print_say(
+                "It appears you are in {CITY}. But you set your location to {LOC}" .format(
+                    CITY=city, LOC=loc), self, Fore.RED)
             print_say("Do you want weather for {CITY} instead? (y/n)"
                       .format(CITY=city), self, Fore.RED)
             i = input()
             if i == 'y' or i == 'yes':
                 try:
-                    print_say("Would you like to set {CITY} as your new location? (y/n)"
-                              .format(CITY=city), self, Fore.RED)
+                    print_say(
+                        "Would you like to set {CITY} as your new location? (y/n)" .format(
+                            CITY=city), self, Fore.RED)
                     i = input()
                     if i == 'y' or i == 'yes':
                         memory.update_data('city', city)
@@ -45,7 +47,7 @@ def main(memory, self, s):
                         umbrella.main(city)
                     else:
                         mapps.weather(city)
-                except:
+                except BaseException:
                     print_say("I couldn't locate you", self, Fore.RED)
             else:
                 try:
@@ -53,7 +55,7 @@ def main(memory, self, s):
                         umbrella.main(loc)
                     else:
                         mapps.weather(loc)
-                except:
+                except BaseException:
                     print_say("I couldn't locate you", self, Fore.RED)
         else:
             try:
@@ -61,5 +63,5 @@ def main(memory, self, s):
                     umbrella.main(loc)
                 else:
                     mapps.weather(loc)
-            except:
+            except BaseException:
                 print_say("I couldn't locate you", self, Fore.RED)

--- a/jarviscli/plugin.py
+++ b/jarviscli/plugin.py
@@ -22,7 +22,9 @@ def plugin(name):
         system("sudo ap-hotspot start")
     """
     def create_plugin(run):
-        plugin_class = type(run.__name__, Plugin.__bases__, dict(Plugin.__dict__))
+        plugin_class = type(
+            run.__name__, Plugin.__bases__, dict(
+                Plugin.__dict__))
         plugin_class.__doc__ = run.__doc__
 
         if isclass(run):
@@ -108,7 +110,12 @@ class Plugin(pluginmanager.IPlugin, PluginStorage):
         (would not be possible with __init__)
         """
         if self.is_callable_plugin():
-            if hasattr(self._backend[0].__class__, "init") and callable(getattr(self._backend[0].__class__, "init")):
+            if hasattr(
+                self._backend[0].__class__,
+                "init") and callable(
+                getattr(
+                    self._backend[0].__class__,
+                    "init")):
                 self._backend[0].init(jarvis_api)
         for plugin in self.get_plugins().values():
             plugin.init(jarvis_api)

--- a/jarviscli/plugins/MipsConverter.py
+++ b/jarviscli/plugins/MipsConverter.py
@@ -29,6 +29,7 @@ class MipsConverter:
     the instruction such as between keyword and register, or keyword
     and immediate, or register and immediate.
     """
+
     def __call__(self, jarvis, s):
         if (s != ""):
             if (len(s) == 8 and s.find(" ") == -1):
@@ -36,7 +37,8 @@ class MipsConverter:
             else:
                 self.assemblyToHex(s, jarvis)
         else:
-            jarvis.say("please enter a valid Assembly statement or a Machine code statement in Hex.")
+            jarvis.say(
+                "please enter a valid Assembly statement or a Machine code statement in Hex.")
 
     def __init__(self):
         # all lists which hold necessary info to interpret the command
@@ -297,7 +299,8 @@ class MipsConverter:
             jarvis.say("NO SUCH COMMAND IN ASSEMBLY")
             return
         else:
-            jarvis.say("The format for this command is: " + self.__com[i] + " " + self.__form[i])
+            jarvis.say("The format for this command is: " +
+                       self.__com[i] + " " + self.__form[i])
             # append the opcode to the binary output
             assBin = assBin + self.__op[i]
 
@@ -305,7 +308,8 @@ class MipsConverter:
             if (self.__inType[i] == "R" and self.__rs[i] == "l"):
                 regR = ""
                 # these instructions have rs register at the end
-                if ((self.__com[i] == "SLLV") or (self.__com[i] == "SRAV") or (self.__com[i] == "SRLV")):
+                if ((self.__com[i] == "SLLV") or (self.__com[i]
+                                                  == "SRAV") or (self.__com[i] == "SRLV")):
                     regR = self.__getRegLast(assembly)
                 # instructions with no d register put rs in the front
                 elif (self.__rd[i] != "l"):
@@ -314,32 +318,40 @@ class MipsConverter:
                 else:
                     regR = self.__getRegSecond(assembly)
 
-                assBin = assBin + self.__getRegBin(regR, self.__regName, self.__regCode, jarvis)
+                assBin = assBin + \
+                    self.__getRegBin(regR, self.__regName, self.__regCode, jarvis)
             # To append rs register, if it is an I type instruction,
             elif(self.__inType[i] == "I" and self.__rs[i] == "l"):
                 regR = ""
-                # these instructions have rs register in the middle of the first and last register
-                if ((self.__com[i] == "SLTI") or (self.__com[i] == "SLTIU") or (self.__com[i] == "ORI")):
+                # these instructions have rs register in the middle of the
+                # first and last register
+                if ((self.__com[i] == "SLTI") or (self.__com[i]
+                                                  == "SLTIU") or (self.__com[i] == "ORI")):
                     regR = self.__getRegSecond(assembly)
                 elif((self.__com[i] == "ANDI") or (self.__com[i] == "ADDI")):
                     regR = self.__getRegSecond(assembly)
-                # these instructions have a form imm(rs) which makes locating rs easy
+                # these instructions have a form imm(rs) which makes locating
+                # rs easy
                 elif (self.__form[i].find("(") != -1):
                     regR = assembly[assembly.find("(") + 1: assembly.find(")")]
                 # the rest put rs in the beginning
                 else:
                     regR = self.__getRegFirst(assembly)
 
-                assBin = assBin + self.__getRegBin(regR, self.__regName, self.__regCode, jarvis)
-            # if rs is niether of the above then rs code is already present in the info
+                assBin = assBin + \
+                    self.__getRegBin(regR, self.__regName, self.__regCode, jarvis)
+            # if rs is niether of the above then rs code is already present in
+            # the info
             elif (self.__rs[i] != "n"):
                 assBin = assBin + self.__rs[i]
 
             # To append rt register, if it is an R type instruction,
             if (self.__inType[i] == "R" and self.__rt[i] == "l"):
                 regR = ""
-                # these instructions have rt in the middle of first and last register
-                if ((self.__com[i] == "SRA") or (self.__com[i] == "SRL") or (self.__com[i] == "SRLV")):
+                # these instructions have rt in the middle of first and last
+                # register
+                if ((self.__com[i] == "SRA") or (self.__com[i]
+                                                 == "SRL") or (self.__com[i] == "SRLV")):
                     regR = self.__getRegSecond(assembly)
                 elif ((self.__com[i] == "SRAV") or (self.__com[i] == "SLL") or (self.__com[i] == "SLLV")):
                     regR = self.__getRegSecond(assembly)
@@ -347,25 +359,30 @@ class MipsConverter:
                 else:
                     regR = self.__getRegLast(assembly)
 
-                assBin = assBin + self.__getRegBin(regR, self.__regName, self.__regCode, jarvis)
+                assBin = assBin + \
+                    self.__getRegBin(regR, self.__regName, self.__regCode, jarvis)
             # To append rt register, if it is an I type instruction,
             elif (self.__inType[i] == "I" and self.__rt[i] == "l"):
                 regR = ""
-                # these instructions have rt in the middle of first and last register
+                # these instructions have rt in the middle of first and last
+                # register
                 if ((self.__com[i] == "BEQ") or (self.__com[i] == "BNE")):
                     regR = self.__getRegSecond(assembly)
                 # the rest have rt at the first pos
                 else:
                     regR = self.__getRegFirst(assembly)
 
-                assBin = assBin + self.__getRegBin(regR, self.__regName, self.__regCode, jarvis)
-            # if rt is niether of the above then rt code is already present in the info
+                assBin = assBin + \
+                    self.__getRegBin(regR, self.__regName, self.__regCode, jarvis)
+            # if rt is niether of the above then rt code is already present in
+            # the info
             elif (self.__rt[i] != "n"):
                 assBin = assBin + self.__rt[i]
 
             # To append rd register, if it is an R type instruction,
             if (self.__inType[i] == "R" and self.__rd[i] == "l"):
-                assBin = assBin + self.__getRegBin(self.__getRegFirst(assembly), self.__regName, self.__regCode, jarvis)
+                assBin = assBin + \
+                    self.__getRegBin(self.__getRegFirst(assembly), self.__regName, self.__regCode, jarvis)
             # rd code is already present in the info
             elif (self.__rd[i] != "n"):
                 assBin = assBin + self.__rd[i]
@@ -377,14 +394,17 @@ class MipsConverter:
                 if (amt.find("x") == -1 and amt != "" and amt.find("$") == -1):
                     if (len(self.__decToBin(amt)) > 5):
                         jarvis.say("Shift amount is too great")
-                    amt = ("0" * (5 - len(self.__decToBin(amt)))) + self.__decToBin(int(amt))
+                    amt = ("0" * (5 - len(self.__decToBin(amt)))) + \
+                        self.__decToBin(int(amt))
                 # handle if amount is in hex
                 else:
                     if (len(self.__hexToBin(amt[2:])) > 5):
                         jarvis.say("Shift amount is too great")
-                    amt = ("0" * (5 - len(self.__hexToBin(amt[2:])))) + self.__hexToBin(amt[2:])
+                    amt = (
+                        "0" * (5 - len(self.__hexToBin(amt[2:])))) + self.__hexToBin(amt[2:])
                 assBin = assBin + amt
-            # if instruction is R type and shift amount is not entered then it is already present in the info
+            # if instruction is R type and shift amount is not entered then it
+            # is already present in the info
             elif (self.__inType[i] == "R"):
                 assBin = assBin + self.__shamt[i]
             # always append the function is instruction is R type
@@ -401,7 +421,8 @@ class MipsConverter:
                 else:
                     immB = assembly[assembly.rfind(" "): assembly.find("(")]
 
-                if (immB.find("x") == -1 and immB != "" and immB.find("$") == -1):
+                if (immB.find("x") == -1 and immB !=
+                        "" and immB.find("$") == -1):
                     immB = self.__decToBin(int(immB))
 
                 else:
@@ -463,28 +484,34 @@ class MipsConverter:
             assembly = assembly + self.__com[i] + " "
             # compute the assembly instruction if instruction is R type
             if (self.__inType[i] == "R"):
-                # handle d register first, d reg always comes first in the R type instructions
+                # handle d register first, d reg always comes first in the R
+                # type instructions
                 if (self.__rd[i] == "l"):
                     regR = command[16:21]
-                    assembly = assembly + self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
+                    assembly = assembly + \
+                        self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
 
                 # handle s register..
                 if (self.__rs[i] == "l"):
-                    if ((self.__com[i] == "SLLV") or (self.__com[i] == "SRAV") or (self.__com[i] == "SRLV")):
+                    if ((self.__com[i] == "SLLV") or (
+                            self.__com[i] == "SRAV") or (self.__com[i] == "SRLV")):
                         regR = command[11:16]
                     else:
                         regR = command[6:11]
 
-                    assembly = assembly + self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
+                    assembly = assembly + \
+                        self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
 
                 # handle t registers..
                 if (self.__rt[i] == "l"):
-                    if ((self.__com[i] == "SLLV") or (self.__com[i] == "SRAV") or (self.__com[i] == "SRLV")):
+                    if ((self.__com[i] == "SLLV") or (
+                            self.__com[i] == "SRAV") or (self.__com[i] == "SRLV")):
                         regR = command[6:11]
                     else:
                         regR = command[11:16]
 
-                    assembly = assembly + self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
+                    assembly = assembly + \
+                        self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
 
                 # handle shift amount
                 if (self.__shamt[i] == "l"):
@@ -500,13 +527,15 @@ class MipsConverter:
                     else:
                         regR = command[11:16]
 
-                    assembly = assembly + self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
+                    assembly = assembly + \
+                        self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
 
                 # handle s registers
                 if (self.__rs[i] == "l"):
                     if ((self.__com[i] == "BNE") or (self.__com[i] == "BEQ")):
                         regR = command[11:16]
-                        assembly = assembly + self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
+                        assembly = assembly + \
+                            self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
 
                     elif (self.__form[i].find("(") != -1):
                         regR = command[16:]
@@ -514,13 +543,15 @@ class MipsConverter:
 
                     else:
                         regR = command[6:11]
-                        assembly = assembly + self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
+                        assembly = assembly + \
+                            self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + " "
 
                 # handle immediate
                 if (self.__imm[i] == "l"):
                     if (self.__form[i].find("(") != -1):
                         regR = command[6:11]
-                        assembly = assembly + "(" + self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + ")"
+                        assembly = assembly + \
+                            "(" + self.__findRegFromBin(regR, self.__regName, self.__regCode, jarvis) + ")"
                     else:
                         regR = command[16:]
                         assembly = assembly + "0x" + self.__binToHex(regR)

--- a/jarviscli/plugins/MipsConverter.py
+++ b/jarviscli/plugins/MipsConverter.py
@@ -299,8 +299,8 @@ class MipsConverter:
             jarvis.say("NO SUCH COMMAND IN ASSEMBLY")
             return
         else:
-            jarvis.say("The format for this command is: " +
-                       self.__com[i] + " " + self.__form[i])
+            jarvis.say("The format for this command is: "
+                       + self.__com[i] + " " + self.__form[i])
             # append the opcode to the binary output
             assBin = assBin + self.__op[i]
 
@@ -421,8 +421,8 @@ class MipsConverter:
                 else:
                     immB = assembly[assembly.rfind(" "): assembly.find("(")]
 
-                if (immB.find("x") == -1 and immB !=
-                        "" and immB.find("$") == -1):
+                if (immB.find("x") == -1 and immB
+                        != "" and immB.find("$") == -1):
                     immB = self.__decToBin(int(immB))
 
                 else:

--- a/jarviscli/plugins/animations.py
+++ b/jarviscli/plugins/animations.py
@@ -7,6 +7,7 @@ import threading
 class SpinnerThread(threading.Thread):
     """SpinnerThread class to show a spinner on
      command line while the program is running"""
+
     def __init__(self, label="Hmmm... ", delay=0.2):
         super(SpinnerThread, self).__init__()
         self.label = label

--- a/jarviscli/plugins/bmi.py
+++ b/jarviscli/plugins/bmi.py
@@ -53,8 +53,9 @@ class Bmi():
             elif c == '2':
                 return 'imperial'
             elif c == 'help me':
-                prompt = ('If you want to calculate on metric system type 1\n'
-                          'If you want to calculate on imperial system type 2: ')
+                prompt = (
+                    'If you want to calculate on metric system type 1\n'
+                    'If you want to calculate on imperial system type 2: ')
                 continue
             elif c == 'try again':
                 prompt = 'Please type 1 for metric and 2 for imperial system: '

--- a/jarviscli/plugins/calories.py
+++ b/jarviscli/plugins/calories.py
@@ -40,7 +40,8 @@ def calories(jarvis, s):
         gender_no = -161
 
     if gender_no != 0 and age > 14 and height > 0.0 and weight > 0.0 and level > 0 and level < 5:
-        brm = float(10 * weight + 6.25 * height - 5 * age + gender_no) * exercise_level(level)
+        brm = float(10 * weight + 6.25 * height - 5 *
+                    age + gender_no) * exercise_level(level)
         brm_loss = brm - 500.0
         brm_put_on = brm + 500.0
         jarvis.say("Daily caloric intake :    " + str(brm))

--- a/jarviscli/plugins/calories.py
+++ b/jarviscli/plugins/calories.py
@@ -40,8 +40,8 @@ def calories(jarvis, s):
         gender_no = -161
 
     if gender_no != 0 and age > 14 and height > 0.0 and weight > 0.0 and level > 0 and level < 5:
-        brm = float(10 * weight + 6.25 * height - 5 *
-                    age + gender_no) * exercise_level(level)
+        brm = float(10 * weight + 6.25 * height - 5
+                    * age + gender_no) * exercise_level(level)
         brm_loss = brm - 500.0
         brm_put_on = brm + 500.0
         jarvis.say("Daily caloric intake :    " + str(brm))

--- a/jarviscli/plugins/cricket.py
+++ b/jarviscli/plugins/cricket.py
@@ -11,6 +11,7 @@ class Cricket():
     """
     Enter cricket and follow the instructions
     """
+
     def __init__(self):
         self.c = Cricbuzz()
 
@@ -38,25 +39,31 @@ class Cricket():
         selected_match = self.all_match_data[index]
         data = self.c.livescore(self.matches[index]['id'])
         score = {}
-        score['matchinfo'] = "{}, {}".format(selected_match['srs'], selected_match['mnum'])
+        score['matchinfo'] = "{}, {}".format(
+            selected_match['srs'], selected_match['mnum'])
         score['status'] = "{}".format(selected_match['status'])
         score['bowling'] = data['bowling']
         score['batting'] = data['batting']
 
         text = ''
-        text += Fore.LIGHTYELLOW_EX + score['matchinfo'] + '\n' + score['status'] + '\n\n'
+        text += Fore.LIGHTYELLOW_EX + \
+            score['matchinfo'] + '\n' + score['status'] + '\n\n'
 
         text += Fore.BLUE + score['batting']['team'] + Fore.BLACK
         for scr in reversed(score['batting']['score']):
-            text += " :- {}/{} in {} overs\n".format(scr['runs'], scr['wickets'], scr['overs'])
+            text += " :- {}/{} in {} overs\n".format(
+                scr['runs'], scr['wickets'], scr['overs'])
         for b in reversed(score['batting']['batsman']):
-            text += "{} : {}({}) \n".format(b['name'].strip('*'), b['runs'], b['balls'])
+            text += "{} : {}({}) \n".format(
+                b['name'].strip('*'), b['runs'], b['balls'])
 
         text += Fore.BLUE + '\n' + score['bowling']['team'] + Fore.BLACK
         for scr in reversed(score['bowling']['score']):
-            text += " :- {}/{} in {} overs\n".format(scr['runs'], scr['wickets'], scr['overs'])
+            text += " :- {}/{} in {} overs\n".format(
+                scr['runs'], scr['wickets'], scr['overs'])
         for b in reversed(score['bowling']['bowler']):
-            text += "{} : {}/{} \n".format(b['name'].strip('*'), b['wickets'], b['runs'])
+            text += "{} : {}/{} \n".format(b['name'].strip('*'),
+                                           b['wickets'], b['runs'])
         text += Fore.RESET
 
         return text
@@ -65,7 +72,8 @@ class Cricket():
         selected_match = self.all_match_data[index]
         data = self.c.commentary(self.matches[index]['id'])
         comm = {}
-        comm['matchinfo'] = "{}, {}".format(selected_match['srs'], selected_match['mnum'])
+        comm['matchinfo'] = "{}, {}".format(
+            selected_match['srs'], selected_match['mnum'])
         comm['status'] = "{}".format(selected_match['status'])
         comm['commentary'] = data['commentary']
         text = []
@@ -75,12 +83,23 @@ class Cricket():
                 line += com['over'] + ' : '
             line += "{}\n\n".format(com['comm'])
             # doing bold breaklines and italics looks good in terminal
-            text.append(line.replace('<b>', '\033[1m').replace('</b>', '\033[0m')
-                            .replace('<br/>', '\n').replace('<i>', '\x1B[3m').replace('</i>', '\x1B[23m'))
+            text.append(
+                line.replace(
+                    '<b>',
+                    '\033[1m').replace(
+                    '</b>',
+                    '\033[0m') .replace(
+                    '<br/>',
+                    '\n').replace(
+                    '<i>',
+                    '\x1B[3m').replace(
+                        '</i>',
+                    '\x1B[23m'))
 
         text.reverse()
 
-        commentary = Fore.LIGHTYELLOW_EX + comm['matchinfo'] + '\n' + comm['status'] + '\n\n' + Fore.RESET
+        commentary = Fore.LIGHTYELLOW_EX + \
+            comm['matchinfo'] + '\n' + comm['status'] + '\n\n' + Fore.RESET
         for line in text:
             commentary += line
 
@@ -90,27 +109,31 @@ class Cricket():
         selected_match = self.all_match_data[index]
         data = self.c.scorecard(self.matches[index]['id'])
         card = {}
-        card['matchinfo'] = "{}, {}".format(selected_match['srs'], selected_match['mnum'])
+        card['matchinfo'] = "{}, {}".format(
+            selected_match['srs'], selected_match['mnum'])
         card['status'] = "{}".format(selected_match['status'])
         card['scorecard'] = data['scorecard']
         text = ''
-        text += Fore.LIGHTYELLOW_EX + card['matchinfo'] + '\n' + card['status'] + '\n\n'
+        text += Fore.LIGHTYELLOW_EX + \
+            card['matchinfo'] + '\n' + card['status'] + '\n\n'
         text += Fore.BLACK + '*' * 35 + '\n\n'
 
         for scr in reversed(card['scorecard']):
-            text += Fore.LIGHTYELLOW_EX + "{}\nInnings: {}\n{}/{} in {} overs\n\n".format(scr['batteam'], scr['inng_num'],
-                                                                                          scr['runs'], scr['wickets'], scr['overs'])
+            text += Fore.LIGHTYELLOW_EX + "{}\nInnings: {}\n{}/{} in {} overs\n\n".format(
+                scr['batteam'], scr['inng_num'], scr['runs'], scr['wickets'], scr['overs'])
             text += Fore.BLUE + "Batting\n"
-            text += Fore.RED + "{:<17} {:<3} {:<3} {:<3} {}\n\n".format('Name', 'R', 'B', '4', '6')
+            text += Fore.RED + \
+                "{:<17} {:<3} {:<3} {:<3} {}\n\n".format('Name', 'R', 'B', '4', '6')
             for b in scr['batcard']:
-                text += Fore.BLACK + "{:<17} {:<3} {:<3} {:<3} {}\n{}\n\n".format(b['name'], b['runs'], b['balls'],
-                                                                                  b['fours'], b['six'], b['dismissal'])
+                text += Fore.BLACK + "{:<17} {:<3} {:<3} {:<3} {}\n{}\n\n".format(
+                    b['name'], b['runs'], b['balls'], b['fours'], b['six'], b['dismissal'])
             text += Fore.LIGHTYELLOW_EX + "-" * 35 + "\n\n"
             text += Fore.BLUE + "Bowling\n"
-            text += Fore.RED + "{:<17} {:<5} {:<3} {:<3} {}\n\n".format('Name', 'O', 'M', 'R', 'W')
+            text += Fore.RED + \
+                "{:<17} {:<5} {:<3} {:<3} {}\n\n".format('Name', 'O', 'M', 'R', 'W')
             for b in scr['bowlcard']:
-                text += Fore.BLACK + "{:<17} {:<5} {:<3} {:<3} {}\n\n".format(b['name'], b['overs'], b['maidens'],
-                                                                              b['runs'], b['wickets'])
+                text += Fore.BLACK + "{:<17} {:<5} {:<3} {:<3} {}\n\n".format(
+                    b['name'], b['overs'], b['maidens'], b['runs'], b['wickets'])
             text += Fore.BLUE + '*' * 35 + '\n\n'
         return text
 
@@ -121,12 +144,20 @@ class Cricket():
             return
         for i, m in enumerate(self.matches, 1):
             print("{}. {} {}".format(str(i), m['srs'], m['mnum']))
-        while 1:
+        while True:
             try:
-                choice = int(input(Fore.RED + '\nEnter choice (number): ' + Fore.RESET))
+                choice = int(
+                    input(
+                        Fore.RED +
+                        '\nEnter choice (number): ' +
+                        Fore.RESET))
                 while choice < 1 or choice > len(self.matches):
                     print(Fore.BLACK + '\nWrong choice')
-                    choice = int(input(Fore.RED + '\nEnter choice again: ' + Fore.RESET))
+                    choice = int(
+                        input(
+                            Fore.RED +
+                            '\nEnter choice again: ' +
+                            Fore.RESET))
                 break
             except ValueError:
                 print("Invalid type of choice. Please enter an integer number")
@@ -145,12 +176,20 @@ class Cricket():
             print('3. Refresh Score')
             print('4. Quit' + Fore.RESET)
 
-            while 1:
+            while True:
                 try:
-                    choice = int(input(Fore.RED + '\nEnter choice (number): ' + Fore.RESET))
+                    choice = int(
+                        input(
+                            Fore.RED +
+                            '\nEnter choice (number): ' +
+                            Fore.RESET))
                     while choice < 1 or choice > 4:
                         print(Fore.BLACK + '\nWrong choice')
-                        choice = int(input(Fore.RED + '\nEnter choice again: ' + Fore.RESET))
+                        choice = int(
+                            input(
+                                Fore.RED +
+                                '\nEnter choice again: ' +
+                                Fore.RESET))
                     break
                 except ValueError:
                     print("Invalid type of choice. Please enter an integer number")
@@ -158,23 +197,38 @@ class Cricket():
 
             if choice == 1:
                 print(self.scorecard(selected_match_id))
-                ref = input(Fore.RED + 'Do you want to refresh:(y/n) ' + Fore.RESET)
+                ref = input(
+                    Fore.RED +
+                    'Do you want to refresh:(y/n) ' +
+                    Fore.RESET)
                 while ref == 'y':
                     print(self.scorecard(selected_match_id))
-                    ref = input(Fore.RED + 'Do you want to refresh:(y/n) ' + Fore.RESET)
+                    ref = input(
+                        Fore.RED +
+                        'Do you want to refresh:(y/n) ' +
+                        Fore.RESET)
 
             elif choice == 2:
                 print(self.commentary(selected_match_id))
-                ref = input(Fore.RED + 'Do you want to refresh:(y/n) ' + Fore.RESET)
+                ref = input(
+                    Fore.RED +
+                    'Do you want to refresh:(y/n) ' +
+                    Fore.RESET)
                 while ref == 'y':
                     print(self.commentary(selected_match_id))
-                    ref = input(Fore.RED + 'Do you want to refresh:(y/n) ' + Fore.RESET)
+                    ref = input(
+                        Fore.RED +
+                        'Do you want to refresh:(y/n) ' +
+                        Fore.RESET)
 
             elif choice == 3:
                 ref = 'y'
                 while ref == 'y':
                     print(self.live_score(selected_match_id))
-                    ref = input(Fore.RED + 'Do you want to refresh:(y/n) ' + Fore.RESET)
+                    ref = input(
+                        Fore.RED +
+                        'Do you want to refresh:(y/n) ' +
+                        Fore.RESET)
 
             else:
                 return

--- a/jarviscli/plugins/cricket.py
+++ b/jarviscli/plugins/cricket.py
@@ -148,16 +148,16 @@ class Cricket():
             try:
                 choice = int(
                     input(
-                        Fore.RED +
-                        '\nEnter choice (number): ' +
-                        Fore.RESET))
+                        Fore.RED
+                        + '\nEnter choice (number): '
+                        + Fore.RESET))
                 while choice < 1 or choice > len(self.matches):
                     print(Fore.BLACK + '\nWrong choice')
                     choice = int(
                         input(
-                            Fore.RED +
-                            '\nEnter choice again: ' +
-                            Fore.RESET))
+                            Fore.RED
+                            + '\nEnter choice again: '
+                            + Fore.RESET))
                 break
             except ValueError:
                 print("Invalid type of choice. Please enter an integer number")
@@ -180,16 +180,16 @@ class Cricket():
                 try:
                     choice = int(
                         input(
-                            Fore.RED +
-                            '\nEnter choice (number): ' +
-                            Fore.RESET))
+                            Fore.RED
+                            + '\nEnter choice (number): '
+                            + Fore.RESET))
                     while choice < 1 or choice > 4:
                         print(Fore.BLACK + '\nWrong choice')
                         choice = int(
                             input(
-                                Fore.RED +
-                                '\nEnter choice again: ' +
-                                Fore.RESET))
+                                Fore.RED
+                                + '\nEnter choice again: '
+                                + Fore.RESET))
                     break
                 except ValueError:
                     print("Invalid type of choice. Please enter an integer number")
@@ -198,37 +198,37 @@ class Cricket():
             if choice == 1:
                 print(self.scorecard(selected_match_id))
                 ref = input(
-                    Fore.RED +
-                    'Do you want to refresh:(y/n) ' +
-                    Fore.RESET)
+                    Fore.RED
+                    + 'Do you want to refresh:(y/n) '
+                    + Fore.RESET)
                 while ref == 'y':
                     print(self.scorecard(selected_match_id))
                     ref = input(
-                        Fore.RED +
-                        'Do you want to refresh:(y/n) ' +
-                        Fore.RESET)
+                        Fore.RED
+                        + 'Do you want to refresh:(y/n) '
+                        + Fore.RESET)
 
             elif choice == 2:
                 print(self.commentary(selected_match_id))
                 ref = input(
-                    Fore.RED +
-                    'Do you want to refresh:(y/n) ' +
-                    Fore.RESET)
+                    Fore.RED
+                    + 'Do you want to refresh:(y/n) '
+                    + Fore.RESET)
                 while ref == 'y':
                     print(self.commentary(selected_match_id))
                     ref = input(
-                        Fore.RED +
-                        'Do you want to refresh:(y/n) ' +
-                        Fore.RESET)
+                        Fore.RED
+                        + 'Do you want to refresh:(y/n) '
+                        + Fore.RESET)
 
             elif choice == 3:
                 ref = 'y'
                 while ref == 'y':
                     print(self.live_score(selected_match_id))
                     ref = input(
-                        Fore.RED +
-                        'Do you want to refresh:(y/n) ' +
-                        Fore.RESET)
+                        Fore.RED
+                        + 'Do you want to refresh:(y/n) '
+                        + Fore.RESET)
 
             else:
                 return

--- a/jarviscli/plugins/currencyconv.py
+++ b/jarviscli/plugins/currencyconv.py
@@ -17,12 +17,15 @@ class Currencyconv():
     Convert an amount of money from a currency to another.
     -- Type currencyconv, press enter and follow the instructions!
     """
+
     def __call__(self, jarvis, s):
         currencies = self.find_currencies()
 
         amount = get_float('Enter an amount: ')
-        from_currency = self.get_currency('Enter from which currency: ', currencies)
-        to_currency = self.get_currency('Enter to which currency: ', currencies)
+        from_currency = self.get_currency(
+            'Enter from which currency: ', currencies)
+        to_currency = self.get_currency(
+            'Enter to which currency: ', currencies)
 
         self.currencyconv(jarvis, amount, from_currency, to_currency)
 
@@ -41,7 +44,8 @@ class Currencyconv():
             result = b.convert_btc_to_cur(Decimal(amount), to)
         else:
             result = c.convert(fr, to, Decimal(amount))
-        outputText = str(amount) + " " + fr + " are equal to " + str(result) + " " + to
+        outputText = str(amount) + " " + fr + \
+            " are equal to " + str(result) + " " + to
         jarvis.say(outputText)
 
     def find_currencies(self):

--- a/jarviscli/plugins/dice.py
+++ b/jarviscli/plugins/dice.py
@@ -14,6 +14,7 @@ class Roll():
         Roll four dices with 16 edges
         Roll 5 dices five times
     """
+
     def __call__(self, jarvis, s):
         config = self._dice_parse(s)
 
@@ -75,13 +76,16 @@ class Roll():
         if config["howmany"] == 0:
             return "No dice to roll?"
         if config["howmany"] < 0:
-            return "Rolling {} dices does not really make sense ;).".format(config["howmany"])
+            return "Rolling {} dices does not really make sense ;).".format(
+                config["howmany"])
         if config["repeat"] == 0:
             return "Roll 0 howmany? Finish!"
         if config["repeat"] < 0:
-            return "Doing something {} does not really make sense ;).".format(config["repeat"])
+            return "Doing something {} does not really make sense ;).".format(
+                config["repeat"])
         if config["edges"] <= 1:
-            return "A dice with {} edges does not really make sense ;).".format(config["edges"])
+            return "A dice with {} edges does not really make sense ;).".format(
+                config["edges"])
 
         return False
 

--- a/jarviscli/plugins/dictionary.py
+++ b/jarviscli/plugins/dictionary.py
@@ -62,7 +62,8 @@ def dictionary(jarvis, s):
     while detail_id is not None:
         meaning = syns[detail_id - 1]
 
-        synonyms = [synonym for synonym in meaning.lemma_names() if synonym != word]
+        synonyms = [synonym for synonym in meaning.lemma_names()
+                    if synonym != word]
         examples = meaning.examples()
 
         antonyms = set()

--- a/jarviscli/plugins/evaluator.py
+++ b/jarviscli/plugins/evaluator.py
@@ -69,8 +69,10 @@ def equations(jarvis, term):
     [{x: -9, y: 1, z: 77}, {x: 1, y: 11, z: 17}]
 
     """
-    a, b, c, d, e, f, g, h, i, j, k, l, m = sympy.symbols('a,b,c,d,e,f,g,h,i,j,k,l,m')
-    n, o, p, q, r, s, t, u, v, w, x, y, z = sympy.symbols('n,o,p,q,r,s,t,u,v,w,x,y,z')
+    a, b, c, d, e, f, g, h, i, j, k, l, m = sympy.symbols(
+        'a,b,c,d,e,f,g,h,i,j,k,l,m')
+    n, o, p, q, r, s, t, u, v, w, x, y, z = sympy.symbols(
+        'n,o,p,q,r,s,t,u,v,w,x,y,z')
 
     equations = []
     count = 1
@@ -82,7 +84,12 @@ def equations(jarvis, term):
         equations.append(user_input)
         user_input = input('{}. Equation: '.format(count))
 
-    calc(jarvis, term, calculator=lambda expr: sympy.solve(equations, dict=True))
+    calc(
+        jarvis,
+        term,
+        calculator=lambda expr: sympy.solve(
+            equations,
+            dict=True))
 
 
 @plugin('factor')
@@ -150,7 +157,8 @@ def limit(jarvis, s):
             if token[1:].isnumeric():
                 limit_to.append(int(token[1:]))
             else:
-                jarvis.say("Error: {} Not a number".format(token[1:]), Fore.RED)
+                jarvis.say("Error: {} Not a number".format(
+                    token[1:]), Fore.RED)
         else:
             term += token
 
@@ -161,8 +169,10 @@ def limit(jarvis, s):
     x = sympy.Symbol('x')
 
     # infinity:
-    jarvis.say("lim ->  ∞\t= {}".format(try_limit(term, x, +sympy.S.Infinity)), Fore.BLUE)
-    jarvis.say("lim -> -∞\t= {}".format(try_limit(term, x, -sympy.S.Infinity)), Fore.BLUE)
+    jarvis.say("lim ->  ∞\t= {}".format(try_limit(term,
+                                                  x, +sympy.S.Infinity)), Fore.BLUE)
+    jarvis.say("lim -> -∞\t= {}".format(try_limit(term,
+                                                  x, -sympy.S.Infinity)), Fore.BLUE)
 
     for limit in limit_to:
         limit_plus = try_limit(term, x, limit, directory="+")
@@ -263,7 +273,8 @@ def curvesketch(jarvis, s):
         curve sketch y=1/3x**3-2x**2+3x
     """
     if len(s) == 0:
-        jarvis.say("Missing parameter: function (e.g. call 'curve sketch y=x**2+10x-5')")
+        jarvis.say(
+            "Missing parameter: function (e.g. call 'curve sketch y=x**2+10x-5')")
         return
 
     def section(jarvis, headline):

--- a/jarviscli/plugins/file_organise.py
+++ b/jarviscli/plugins/file_organise.py
@@ -26,8 +26,8 @@ class File_Organise():
         home_path = home_dir.split(user_name)[0].rstrip('/')
         for root in os.walk(home_path):
             print(
-                Fore.LIGHTBLUE_EX +
-                "Searching in {}...".format(
+                Fore.LIGHTBLUE_EX
+                + "Searching in {}...".format(
                     (root[0])[
                         :70]),
                 end="\r")

--- a/jarviscli/plugins/file_organise.py
+++ b/jarviscli/plugins/file_organise.py
@@ -12,6 +12,7 @@ class File_Organise():
     Type file_organise and follow instructions
     It organises selected folder based on extension
     """
+
     def __call__(self, jarvis, s):
         self.file_manage(jarvis)
 
@@ -24,7 +25,12 @@ class File_Organise():
         user_name = os.environ.get("USER")
         home_path = home_dir.split(user_name)[0].rstrip('/')
         for root in os.walk(home_path):
-            print(Fore.LIGHTBLUE_EX + "Searching in {}...".format((root[0])[:70]), end="\r")
+            print(
+                Fore.LIGHTBLUE_EX +
+                "Searching in {}...".format(
+                    (root[0])[
+                        :70]),
+                end="\r")
             sys.stdout.flush()
             if dir_name == root[0].split('/')[-1]:
                 all_paths.append(root[0])
@@ -88,7 +94,8 @@ class File_Organise():
 
             else:
                 for f in os.listdir(path):
-                    if f != new_dir and os.path.splitext(f)[1].strip('.') == ext:
+                    if f != new_dir and os.path.splitext(
+                            f)[1].strip('.') == ext:
                         inner_folder = os.path.join(new_dir_path, f)
 
                         if os.path.exists(inner_folder):

--- a/jarviscli/plugins/game.py
+++ b/jarviscli/plugins/game.py
@@ -38,17 +38,21 @@ def bulls_and_cows(jarvis, s):
     jarvis.say(Fore.CYAN + 'Rules of the game:\n')
     jarvis.say('* You should guess 4-digit number where all digits are different.')
     jarvis.say('* After each try you will receive the number of matches.')
-    jarvis.say('* If the matching digits are in their right positions, they are "bulls"')
+    jarvis.say(
+        '* If the matching digits are in their right positions, they are "bulls"')
     jarvis.say('* Otherwise, if in different positions, they are "cows".')
     jarvis.say(Fore.CYAN + 'Example:')
-    jarvis.say('\tSecret number: 4271\n\tYour try: 1234\n\tAnswer: 1 bull and 2 cows.')
+    jarvis.say(
+        '\tSecret number: 4271\n\tYour try: 1234\n\tAnswer: 1 bull and 2 cows.')
     jarvis.say('\tThe bull is "2", the cows are "4" and "1".')
     jarvis.say(Fore.CYAN + 'Lets start? Type "g" to start or "q" to quit:')
 
     while(True):
         st = input()
         if st == 'q':
-            jarvis.say(Fore.CYAN + 'Thank you for playing! New games are coming soon!')
+            jarvis.say(
+                Fore.CYAN +
+                'Thank you for playing! New games are coming soon!')
             break
         else:
             tries = int(0)
@@ -64,7 +68,9 @@ def bulls_and_cows(jarvis, s):
 
             # loop while the secret number is found or user quits
             while(True):
-                jarvis.say(Fore.CYAN + 'Enter your guess, please (type "q" to quit):')
+                jarvis.say(
+                    Fore.CYAN +
+                    'Enter your guess, please (type "q" to quit):')
                 guess_num = input()
                 if guess_num == 'q':
                     jarvis.say(Fore.CYAN + 'Thank you for playing!')
@@ -73,14 +79,38 @@ def bulls_and_cows(jarvis, s):
                 guess_num = int(guess_num)
                 cows = int(0)
                 bulls = int(0)
-                cows, bulls = check(checker, guess_num, 1000, 10000, checker[a], cows, bulls)
-                cows, bulls = check(checker, guess_num, 100, 1000, checker[b], cows, bulls)
-                cows, bulls = check(checker, guess_num, 10, 100, checker[c], cows, bulls)
-                cows, bulls = check(checker, guess_num, 1, 10, checker[d], cows, bulls)
-                jarvis.say(Fore.CYAN + 'Cows: ' + str(cows) + '\tBulls: ' + str(bulls) + '\n')
+                cows, bulls = check(
+                    checker, guess_num, 1000, 10000, checker[a], cows, bulls)
+                cows, bulls = check(
+                    checker, guess_num, 100, 1000, checker[b], cows, bulls)
+                cows, bulls = check(
+                    checker, guess_num, 10, 100, checker[c], cows, bulls)
+                cows, bulls = check(
+                    checker, guess_num, 1, 10, checker[d], cows, bulls)
+                jarvis.say(
+                    Fore.CYAN +
+                    'Cows: ' +
+                    str(cows) +
+                    '\tBulls: ' +
+                    str(bulls) +
+                    '\n')
                 if bulls == 4:
-                    jarvis.say(Fore.CYAN + 'Congratulations! Your guess is right:')
-                    jarvis.say('\t' + Fore.GREEN + str(a) + str(b) + str(c) + str(d))
-                    jarvis.say(Fore.CYAN + 'You made ' + Fore.GREEN + str(tries) + Fore.CYAN + ' tries.')
-                    jarvis.say(Fore.CYAN + 'Start a new game or quit? (Type "s" or "q"):')
+                    jarvis.say(Fore.CYAN +
+                               'Congratulations! Your guess is right:')
+                    jarvis.say(
+                        '\t' +
+                        Fore.GREEN +
+                        str(a) +
+                        str(b) +
+                        str(c) +
+                        str(d))
+                    jarvis.say(
+                        Fore.CYAN +
+                        'You made ' +
+                        Fore.GREEN +
+                        str(tries) +
+                        Fore.CYAN +
+                        ' tries.')
+                    jarvis.say(Fore.CYAN +
+                               'Start a new game or quit? (Type "s" or "q"):')
                     break

--- a/jarviscli/plugins/game.py
+++ b/jarviscli/plugins/game.py
@@ -51,8 +51,8 @@ def bulls_and_cows(jarvis, s):
         st = input()
         if st == 'q':
             jarvis.say(
-                Fore.CYAN +
-                'Thank you for playing! New games are coming soon!')
+                Fore.CYAN
+                + 'Thank you for playing! New games are coming soon!')
             break
         else:
             tries = int(0)
@@ -69,8 +69,8 @@ def bulls_and_cows(jarvis, s):
             # loop while the secret number is found or user quits
             while(True):
                 jarvis.say(
-                    Fore.CYAN +
-                    'Enter your guess, please (type "q" to quit):')
+                    Fore.CYAN
+                    + 'Enter your guess, please (type "q" to quit):')
                 guess_num = input()
                 if guess_num == 'q':
                     jarvis.say(Fore.CYAN + 'Thank you for playing!')
@@ -88,29 +88,29 @@ def bulls_and_cows(jarvis, s):
                 cows, bulls = check(
                     checker, guess_num, 1, 10, checker[d], cows, bulls)
                 jarvis.say(
-                    Fore.CYAN +
-                    'Cows: ' +
-                    str(cows) +
-                    '\tBulls: ' +
-                    str(bulls) +
-                    '\n')
+                    Fore.CYAN
+                    + 'Cows: '
+                    + str(cows)
+                    + '\tBulls: '
+                    + str(bulls)
+                    + '\n')
                 if bulls == 4:
-                    jarvis.say(Fore.CYAN +
-                               'Congratulations! Your guess is right:')
+                    jarvis.say(Fore.CYAN
+                               + 'Congratulations! Your guess is right:')
                     jarvis.say(
-                        '\t' +
-                        Fore.GREEN +
-                        str(a) +
-                        str(b) +
-                        str(c) +
-                        str(d))
+                        '\t'
+                        + Fore.GREEN
+                        + str(a)
+                        + str(b)
+                        + str(c)
+                        + str(d))
                     jarvis.say(
-                        Fore.CYAN +
-                        'You made ' +
-                        Fore.GREEN +
-                        str(tries) +
-                        Fore.CYAN +
-                        ' tries.')
-                    jarvis.say(Fore.CYAN +
-                               'Start a new game or quit? (Type "s" or "q"):')
+                        Fore.CYAN
+                        + 'You made '
+                        + Fore.GREEN
+                        + str(tries)
+                        + Fore.CYAN
+                        + ' tries.')
+                    jarvis.say(Fore.CYAN
+                               + 'Start a new game or quit? (Type "s" or "q"):')
                     break

--- a/jarviscli/plugins/gmail.py
+++ b/jarviscli/plugins/gmail.py
@@ -11,12 +11,14 @@ def gmail(jarvis, s):
                 2. Less secure apps should be allowed to access the gmail account.
     '''
     try:
-        server = smtplib.SMTP("smtp.gmail.com", 587)         # establshing server connection
+        # establshing server connection
+        server = smtplib.SMTP("smtp.gmail.com", 587)
         server.ehlo()
         server.starttls()
         print("SERVER CONNECTED")
-    except:
-        print("Could Not connect to Gmail")                  # in case of failure
+    except BaseException:
+        # in case of failure
+        print("Could Not connect to Gmail")
         return
     user = input("Enter User id\n")                          # YOUR ID
     Pass_w = input("\nEnter your Password\n")                # YOUR Password
@@ -26,8 +28,9 @@ def gmail(jarvis, s):
     try:
         server.login(user, Pass_w)                           # user log in
         print("User Logged in")
-    except:
-        print('''Allow Less secure apps in GOOGLE ACCOUNT SETTINGS to use SMTP services by following the given steps:
+    except BaseException:
+        print(
+            '''Allow Less secure apps in GOOGLE ACCOUNT SETTINGS to use SMTP services by following the given steps:
                                                                       \n\t\tStep 1. Log in to email using your browser.
                                                                       \n\t\tStep 2. Go to account settings.
                                                                       \n\t\tStep 3. Find 'allow less secure apps' and mark it as ON.''')
@@ -36,5 +39,6 @@ def gmail(jarvis, s):
     server.sendmail(user, reciever_id, msg)
     print("MAIL sent")                                       # confirmation
     print("Closing Connection")
-    server.quit()                                            # closing server connection
+    # closing server connection
+    server.quit()
     print("Server closed")

--- a/jarviscli/plugins/hackathon.py
+++ b/jarviscli/plugins/hackathon.py
@@ -11,6 +11,7 @@ class Hackathon():
     """
     Find upcoming hackathons from hackerearth
     """
+
     def __call__(self, jarvis, s):
         jarvis.say('--- Fetching hackathons--- \n')
         self.format(self.get_hackathon_data(self.get_csrf_token()), jarvis)
@@ -19,7 +20,8 @@ class Hackathon():
         csrf_request = requests.get('https://www.hackerearth.com/challenges/')
 
         # extract line with CSRF_COOKIE =
-        csrf_token = [line for line in csrf_request.text.split('\n') if 'var CSRF_COOKIE =' in line][0]
+        csrf_token = [line for line in csrf_request.text.split(
+            '\n') if 'var CSRF_COOKIE =' in line][0]
 
         # extract lines between ""
         csrf_token = csrf_token.split('"')[1]
@@ -34,7 +36,11 @@ class Hackathon():
         cookie = {}
         cookie['csrftoken'] = csrf_token
 
-        request = requests.post('https://www.hackerearth.com/AJAX/filter-challenges/', data='', headers=headers, cookies=cookie)
+        request = requests.post(
+            'https://www.hackerearth.com/AJAX/filter-challenges/',
+            data='',
+            headers=headers,
+            cookies=cookie)
 
         return request.text
 
@@ -48,12 +54,23 @@ class Hackathon():
 
         if upcoming is not None:
 
-            all_hackathons = upcoming.find_all('div', {'class': 'challenge-content'})
+            all_hackathons = upcoming.find_all(
+                'div', {'class': 'challenge-content'})
 
             for i, hackathon in enumerate(all_hackathons, 1):
-                challenge_type = hackathon.find('div', {'class': 'challenge-type'}).text.replace("\n", " ").strip()
-                challenge_name = hackathon.find('div', {'class': 'challenge-name'}).text.replace("\n", " ").strip()
-                date_time = hackathon.find('div', {'class': 'challenge-list-meta challenge-card-wrapper'}).text.replace("\n", " ").strip()
-                jarvis.say("[{}] {}\n{}\n{}\n\n".format(str(i), challenge_name, challenge_type, date_time))
+                challenge_type = hackathon.find(
+                    'div', {'class': 'challenge-type'}).text.replace("\n", " ").strip()
+                challenge_name = hackathon.find(
+                    'div', {'class': 'challenge-name'}).text.replace("\n", " ").strip()
+                date_time = hackathon.find(
+                    'div', {
+                        'class': 'challenge-list-meta challenge-card-wrapper'}).text.replace(
+                    "\n", " ").strip()
+                jarvis.say(
+                    "[{}] {}\n{}\n{}\n\n".format(
+                        str(i),
+                        challenge_name,
+                        challenge_type,
+                        date_time))
         else:
             jarvis.say("No hackathon data found.")

--- a/jarviscli/plugins/imgur.py
+++ b/jarviscli/plugins/imgur.py
@@ -45,7 +45,8 @@ def imgur(jarvis, s):
             objresp = json.loads(resp.text)
             # Treat response
             if objresp.get('success', False):
-                jarvis.say('Here is your image: ' + str(objresp['data']['link']))
+                jarvis.say('Here is your image: ' +
+                           str(objresp['data']['link']))
             else:
                 jarvis.say('Error: ' + str(objresp['data']['error']))
         except Exception as e:

--- a/jarviscli/plugins/imgur.py
+++ b/jarviscli/plugins/imgur.py
@@ -45,8 +45,8 @@ def imgur(jarvis, s):
             objresp = json.loads(resp.text)
             # Treat response
             if objresp.get('success', False):
-                jarvis.say('Here is your image: ' +
-                           str(objresp['data']['link']))
+                jarvis.say('Here is your image: '
+                           + str(objresp['data']['link']))
             else:
                 jarvis.say('Error: ' + str(objresp['data']['error']))
         except Exception as e:

--- a/jarviscli/plugins/ip.py
+++ b/jarviscli/plugins/ip.py
@@ -10,6 +10,7 @@ class IP():
     """
     Display local and public ip address
     """
+
     def __init__(self):
         self._local_ip = """ifconfig | grep -Eo 'inet (addr:)?([0-9]*\\.){3}[0-9]*' |
                     grep -Eo '([0-9]*\\.){3}[0-9]*' | grep -v '127.0.0.1'"""

--- a/jarviscli/plugins/lyrics.py
+++ b/jarviscli/plugins/lyrics.py
@@ -16,16 +16,19 @@ class lyrics():
     -- Example:
         lyrics wonderful tonight-eric clapton
     """
+
     def __call__(self, jarvis, s):
         jarvis.say(self.find(s))
 
     # info[0] = song
     # info[1] = artist
-    # info[2] = either options or album, depending on how i extend the functionality
+    # info[2] = either options or album, depending on how i extend the
+    # functionality
     def find(self, s):
         info = self.parse(s)
         # TODO: implement find album/song functions
-        # TODO: implement actual searches in case of not knowing the correct full name of song or artist
+        # TODO: implement actual searches in case of not knowing the correct
+        # full name of song or artist
 
         artist = None
         song = None
@@ -87,7 +90,8 @@ def get_lyric(singer, song):
         for match in lyrics.findAll(tag):
             match.replaceWithChildren()
 
-    # TODO: check if you need the encode/decode thing, if you do then do a try catch for it
+    # TODO: check if you need the encode/decode thing, if you do then do a try
+    # catch for it
 
     # get output as string and remove non unicode characters and replace <br> with newlines
     # output = str(lyrics).encode('utf-8', errors = 'replace')[22:-6:] \
@@ -95,5 +99,5 @@ def get_lyric(singer, song):
     output = str(lyrics).replace('\n', '').replace('<br/>', '\n')[22:-6:]
     try:
         return output
-    except:
+    except BaseException:
         return output.encode('utf-8')

--- a/jarviscli/plugins/movie.py
+++ b/jarviscli/plugins/movie.py
@@ -221,7 +221,8 @@ def get_movie_info(jarvis, data):
     Takes a movie attributes as input and prints them accordingly
     """
     jarvis.say('')
-    jarvis.say('What type of information do you want: cast, producers, genres, etc.?')
+    jarvis.say(
+        'What type of information do you want: cast, producers, genres, etc.?')
     jarvis.say('Write one after another separated by space, please:')
 
     movie_attributes = input()
@@ -244,7 +245,10 @@ def get_movie_info(jarvis, data):
 
             jarvis.say(colorized_output(attribute.capitalize(), str(value)))
         else:
-            jarvis.say(colorized_output(attribute.capitalize(), 'no information retrieved'))
+            jarvis.say(
+                colorized_output(
+                    attribute.capitalize(),
+                    'no information retrieved'))
 
     # print IMDB url of the movie
 

--- a/jarviscli/plugins/music.py
+++ b/jarviscli/plugins/music.py
@@ -7,7 +7,8 @@ from plugin import plugin, alias, require, LINUX
 def find_cached_music(music):
     find = os.popen("ls music -tc")
     music = str(find.readline()).replace("\n", "")
-    music = music.replace(" ", "\\ ").replace(" (", " \\("). replace(")", "\\)")
+    music = music.replace(" ", "\\ ").replace(
+        " (", " \\("). replace(")", "\\)")
     return music
 
 
@@ -31,11 +32,17 @@ def play(jarvis, data):
 
         # Try download if not exists
         if not music:
-            os.system("cd music && instantmusic -s '" + data + "' 2> /dev/null")
+            os.system(
+                "cd music && instantmusic -s '" +
+                data +
+                "' 2> /dev/null")
             music = find_cached_music(data)
 
         # Try play if exists
         if not music:
             jarvis.say("Something seems to went wrong...", Fore.BLUE)
         else:
-            os.system("XDG_CURRENT_DESKTOP= DESKTOP_SESSION= xdg-open music/" + music + " 2> /dev/null")
+            os.system(
+                "XDG_CURRENT_DESKTOP= DESKTOP_SESSION= xdg-open music/" +
+                music +
+                " 2> /dev/null")

--- a/jarviscli/plugins/music.py
+++ b/jarviscli/plugins/music.py
@@ -33,9 +33,9 @@ def play(jarvis, data):
         # Try download if not exists
         if not music:
             os.system(
-                "cd music && instantmusic -s '" +
-                data +
-                "' 2> /dev/null")
+                "cd music && instantmusic -s '"
+                + data
+                + "' 2> /dev/null")
             music = find_cached_music(data)
 
         # Try play if exists
@@ -43,6 +43,6 @@ def play(jarvis, data):
             jarvis.say("Something seems to went wrong...", Fore.BLUE)
         else:
             os.system(
-                "XDG_CURRENT_DESKTOP= DESKTOP_SESSION= xdg-open music/" +
-                music +
-                " 2> /dev/null")
+                "XDG_CURRENT_DESKTOP= DESKTOP_SESSION= xdg-open music/"
+                + music
+                + " 2> /dev/null")

--- a/jarviscli/plugins/news.py
+++ b/jarviscli/plugins/news.py
@@ -17,9 +17,21 @@ else:
 class News:
 
     def __init__(self):
-        self.sources = ['bloomberg', 'financial-times', 'cnbc', 'reuters', 'al-jazeera-english',
-                        'the-wall-street-journal', 'the-huffington-post', 'business-insider', 'the-new-york-times',
-                        'abc-news', 'fox-news', 'cnn', 'google-news', 'wired']
+        self.sources = [
+            'bloomberg',
+            'financial-times',
+            'cnbc',
+            'reuters',
+            'al-jazeera-english',
+            'the-wall-street-journal',
+            'the-huffington-post',
+            'business-insider',
+            'the-new-york-times',
+            'abc-news',
+            'fox-news',
+            'cnn',
+            'google-news',
+            'wired']
         self.source_dict = {}
 
         for source in self.sources:
@@ -27,7 +39,8 @@ class News:
 
     def __call__(self, jarvis, s):
         if s == "updatekey":
-            key = input("Please enter your NEWS API key (q or Enter go back): ")
+            key = input(
+                "Please enter your NEWS API key (q or Enter go back): ")
             if key.lower() == "q" or key.lower() == "":
                 jarvis.say("Could not update the NEWS API key! ", Fore.RED)
             else:
@@ -42,15 +55,20 @@ class News:
             jarvis.say("Command\t\t | Description")
             jarvis.say("-------------------------------------")
             jarvis.say("news\t\t : Finds top headlines")
-            jarvis.say("news updatekey\t : Updates the news API key of the user")
-            jarvis.say("news configure\t : Configures the news channel of the user")
+            jarvis.say(
+                "news updatekey\t : Updates the news API key of the user")
+            jarvis.say(
+                "news configure\t : Configures the news channel of the user")
             jarvis.say("news sources\t : List the configured news sources")
-            jarvis.say("news remove\t : Removes a source from the news channel of the user")
+            jarvis.say(
+                "news remove\t : Removes a source from the news channel of the user")
             jarvis.say("news [word]\t : Finds articles related to that word")
         elif s == "sources":
             sources = self.get_news_sources(jarvis)
             if not sources:
-                jarvis.say("No sources configured. Use 'news configure' to add sources.", Fore.RED)
+                jarvis.say(
+                    "No sources configured. Use 'news configure' to add sources.",
+                    Fore.RED)
             else:
                 dic = {}
                 for source in sources:
@@ -61,7 +79,9 @@ class News:
         elif self.get_api_key(jarvis) is None:
             jarvis.say("Missing API key", Fore.RED)
             jarvis.say("Visit https://newsapi.org/ to get the key", Fore.RED)
-            jarvis.say("Use \'news updatekey\' command to add a key\n", Fore.RED)
+            jarvis.say(
+                "Use \'news updatekey\' command to add a key\n",
+                Fore.RED)
         elif s == "" or s == " ":
             self.parse_articles(self.get_headlines(jarvis), jarvis)
         else:
@@ -104,9 +124,15 @@ class News:
         if news_source not in sources:
             sources.append(news_source)
             jarvis.update_data("news-sources", sources)
-            jarvis.say(news_source + " has been successfully been added to your sources!", Fore.GREEN)
+            jarvis.say(
+                news_source +
+                " has been successfully been added to your sources!",
+                Fore.GREEN)
         else:
-            jarvis.say(news_source + " was already included in your sources!", Fore.GREEN)
+            jarvis.say(
+                news_source +
+                " was already included in your sources!",
+                Fore.GREEN)
         return self.get_news_sources(jarvis)
 
     def remove_source(self, jarvis):
@@ -121,8 +147,9 @@ class News:
 
         for index in sorted([int(x) for x in dic.keys()]):
             jarvis.say(str(index) + " : " + dic[str(index)])
-        index_list = input("Type the indexes of the sources you would like to remove from your channel separated by "
-                           "space: ")
+        index_list = input(
+            "Type the indexes of the sources you would like to remove from your channel separated by "
+            "space: ")
         index_list = index_list.split(" ")
         if " " in index_list:
             index_list.remove(" ")
@@ -133,7 +160,10 @@ class News:
                 source = dic[str(index)]
                 sources.remove(source)
                 jarvis.update_data("news-sources", sources)
-                jarvis.say(source + " has been successfully removed from your news channel!", Fore.GREEN)
+                jarvis.say(
+                    source +
+                    " has been successfully removed from your news channel!",
+                    Fore.GREEN)
             else:
                 jarvis.say("Index not found!", Fore.RED)
         return self.get_news_sources(jarvis)
@@ -144,8 +174,9 @@ class News:
         """
         for index in sorted([int(x) for x in self.source_dict.keys()]):
             jarvis.say(str(index) + ": " + self.source_dict.get(str(index)))
-        index_list = input("Type the indexes of the sources you would like to add to your channel separated by "
-                           "space: ")
+        index_list = input(
+            "Type the indexes of the sources you would like to add to your channel separated by "
+            "space: ")
         index_list = index_list.split(" ")
         if " " in index_list:
             index_list.remove(" ")
@@ -164,8 +195,11 @@ class News:
         sources = self.get_news_sources(jarvis)
 
         if len(sources) == 0:
-            jarvis.say("You have not configured any source. Getting top headlines\n", Fore.GREEN)
-            url = "https://newsapi.org/v2/top-headlines?country=us&apiKey=" + self.get_api_key(jarvis)
+            jarvis.say(
+                "You have not configured any source. Getting top headlines\n",
+                Fore.GREEN)
+            url = "https://newsapi.org/v2/top-headlines?country=us&apiKey=" + \
+                self.get_api_key(jarvis)
         else:
             url = "https://newsapi.org/v2/top-headlines?sources="
             for source in sources:
@@ -204,7 +238,8 @@ class News:
                 return None
             # Catch some other errors
             else:
-                jarvis.say("An error occured: Error code: " + str(err.code), Fore.RED)
+                jarvis.say("An error occured: Error code: " +
+                           str(err.code), Fore.RED)
                 return None
 
         # Load json
@@ -244,7 +279,7 @@ class News:
                 return
             elif int(idx) == 0:
                 return
-        except:
+        except BaseException:
             jarvis.say("Not a valid index", Fore.RED)
             return
 

--- a/jarviscli/plugins/news.py
+++ b/jarviscli/plugins/news.py
@@ -125,13 +125,13 @@ class News:
             sources.append(news_source)
             jarvis.update_data("news-sources", sources)
             jarvis.say(
-                news_source +
-                " has been successfully been added to your sources!",
+                news_source
+                + " has been successfully been added to your sources!",
                 Fore.GREEN)
         else:
             jarvis.say(
-                news_source +
-                " was already included in your sources!",
+                news_source
+                + " was already included in your sources!",
                 Fore.GREEN)
         return self.get_news_sources(jarvis)
 
@@ -161,8 +161,8 @@ class News:
                 sources.remove(source)
                 jarvis.update_data("news-sources", sources)
                 jarvis.say(
-                    source +
-                    " has been successfully removed from your news channel!",
+                    source
+                    + " has been successfully removed from your news channel!",
                     Fore.GREEN)
             else:
                 jarvis.say("Index not found!", Fore.RED)
@@ -238,8 +238,8 @@ class News:
                 return None
             # Catch some other errors
             else:
-                jarvis.say("An error occured: Error code: " +
-                           str(err.code), Fore.RED)
+                jarvis.say("An error occured: Error code: "
+                           + str(err.code), Fore.RED)
                 return None
 
         # Load json

--- a/jarviscli/plugins/quote.py
+++ b/jarviscli/plugins/quote.py
@@ -12,6 +12,7 @@ class Quote():
     """
     quote prints quote for the day for you or quotes based on a given keyword
     """
+
     def __call__(self, jarvis, s):
         prompt = 'Press 1 to get the quote of the day \n or 2 to get quotes based on a keyword: '
         user_input = self.get_input(prompt, jarvis)
@@ -24,7 +25,8 @@ class Quote():
             self.get_keyword_quotes(jarvis, keyword)
 
     def get_quote_of_the_day(self, jarvis):
-        res = requests.get('https://www.brainyquote.com/quotes_of_the_day.html')
+        res = requests.get(
+            'https://www.brainyquote.com/quotes_of_the_day.html')
         soup = bs4.BeautifulSoup(res.text, 'lxml')
 
         quote = soup.find('img', {'class': 'p-qotd'})
@@ -48,7 +50,8 @@ class Quote():
                 flag = True  # there is at least one quote
 
         if not flag:
-            jarvis.say('No quotes inlcude this word. PLease try one more time.\n')
+            jarvis.say(
+                'No quotes inlcude this word. PLease try one more time.\n')
             self.try_again(keyword, jarvis)
         else:
             jarvis.say('')

--- a/jarviscli/plugins/random_password.py
+++ b/jarviscli/plugins/random_password.py
@@ -11,7 +11,7 @@ def random_password(jarvis, s):
         try:
             stringLength = int(input("Enter password length: "))
             stringFail = False
-        except:
+        except BaseException:
             print('Only integers will be accepted')
 
     prompt = 'Do you want special characters?(y/n): '
@@ -37,4 +37,5 @@ def random_password(jarvis, s):
 
     """Generate a random string of fixed length """
     preText = 'Your random password is: '
-    print(preText + ''.join(random.choice(password) for _ in range(stringLength)))
+    print(preText + ''.join(random.choice(password)
+                            for _ in range(stringLength)))

--- a/jarviscli/plugins/reminder.py
+++ b/jarviscli/plugins/reminder.py
@@ -200,7 +200,13 @@ class RemindBase(RemindTodoBase):
             remind_still_active += [item]
         self.save_data(jarvis, remind_still_active)
 
-    def add(self, jarvis, message, timestamp=None, schedule_id=None, todo_refere_id=None):
+    def add(
+            self,
+            jarvis,
+            message,
+            timestamp=None,
+            schedule_id=None,
+            todo_refere_id=None):
         data = self.get_data(jarvis)
         next_id = self.get_next_id(jarvis)
         new_entry = {

--- a/jarviscli/plugins/stock.py
+++ b/jarviscli/plugins/stock.py
@@ -13,9 +13,9 @@ class Stock:
     def get_stock_data(quote):
 
         resp = requests.get(
-            'https://api.iextrading.com/1.0/stock/' +
-            quote +
-            '/quote')
+            'https://api.iextrading.com/1.0/stock/'
+            + quote
+            + '/quote')
 
         if resp.status_code == 200:
             resp = resp.json()

--- a/jarviscli/plugins/stock.py
+++ b/jarviscli/plugins/stock.py
@@ -12,7 +12,10 @@ class Stock:
     @staticmethod
     def get_stock_data(quote):
 
-        resp = requests.get('https://api.iextrading.com/1.0/stock/' + quote + '/quote')
+        resp = requests.get(
+            'https://api.iextrading.com/1.0/stock/' +
+            quote +
+            '/quote')
 
         if resp.status_code == 200:
             resp = resp.json()

--- a/jarviscli/plugins/systemOptions.py
+++ b/jarviscli/plugins/systemOptions.py
@@ -24,7 +24,11 @@ def screen_off__LINUX(jarvis, s):
 @plugin('os')
 def Os__MAC(jarvis, s):
     """Displays information about your operating system"""
-    jarvis.say(Style.BRIGHT + '[!] Operating System Information' + Style.RESET_ALL, Fore.BLUE)
+    jarvis.say(
+        Style.BRIGHT +
+        '[!] Operating System Information' +
+        Style.RESET_ALL,
+        Fore.BLUE)
     jarvis.say('[*] Kernel: ' + sys(), Fore.GREEN)
     jarvis.say('[*] Kernel Release Version: ' + release(), Fore.GREEN)
     jarvis.say('[*] macOS System version: ' + mac_ver()[0], Fore.GREEN)

--- a/jarviscli/plugins/systemOptions.py
+++ b/jarviscli/plugins/systemOptions.py
@@ -25,9 +25,9 @@ def screen_off__LINUX(jarvis, s):
 def Os__MAC(jarvis, s):
     """Displays information about your operating system"""
     jarvis.say(
-        Style.BRIGHT +
-        '[!] Operating System Information' +
-        Style.RESET_ALL,
+        Style.BRIGHT
+        + '[!] Operating System Information'
+        + Style.RESET_ALL,
         Fore.BLUE)
     jarvis.say('[*] Kernel: ' + sys(), Fore.GREEN)
     jarvis.say('[*] Kernel Release Version: ' + release(), Fore.GREEN)

--- a/jarviscli/plugins/tempconv.py
+++ b/jarviscli/plugins/tempconv.py
@@ -10,6 +10,7 @@ class Tempconv():
     Convert temperature from Fahrenheit to Celsius and vice versa
     Examples: 32f, 18C, -20F, -8c, 105.4F, -10.21C
     """
+
     def __call__(self, jarvis, s):
         # Pass the input string to the regex validation function.
         if self.temp_valid_regex(s):
@@ -17,7 +18,9 @@ class Tempconv():
 
         # Print an error if the input string fails the regex test.
         else:
-            jarvis.say("I'm sorry, invalid input. Please see \"help tempconv\" for syntax.", Fore.RED)
+            jarvis.say(
+                "I'm sorry, invalid input. Please see \"help tempconv\" for syntax.",
+                Fore.RED)
 
     def temp_valid_regex(self, s):
         """Validate the input string using regex and return a boolean for validity"""

--- a/jarviscli/plugins/translate.py
+++ b/jarviscli/plugins/translate.py
@@ -13,7 +13,10 @@ def translate(jarvis, s):
 
     jarvis.say('\nEnter source language ')
     srcs = input().lower()
-    while (srcs not in LANGUAGES) and (srcs not in SPECIAL_CASES) and (srcs not in LANGCODES):
+    while (
+        srcs not in LANGUAGES) and (
+        srcs not in SPECIAL_CASES) and (
+            srcs not in LANGCODES):
         if srcs in SPECIAL_CASES:
             srcs = SPECIAL_CASES[srcs]
         elif srcs in LANGCODES:
@@ -23,7 +26,10 @@ def translate(jarvis, s):
             srcs = input().lower()
     jarvis.say('\nEnter destination language ')
     des = input().lower()
-    while (des not in LANGUAGES) and (des not in SPECIAL_CASES) and (des not in LANGCODES):
+    while (
+        des not in LANGUAGES) and (
+        des not in SPECIAL_CASES) and (
+            des not in LANGCODES):
         if des in SPECIAL_CASES:
             des = SPECIAL_CASES[des]
         elif des in LANGCODES:

--- a/jarviscli/plugins/voice_control.py
+++ b/jarviscli/plugins/voice_control.py
@@ -11,7 +11,8 @@ except ImportError:
 if voice_control_installed:
     requirements = []
 else:
-    requirements = ['voice_control_requirements (install portaudio + re-run setup.sh)']
+    requirements = [
+        'voice_control_requirements (install portaudio + re-run setup.sh)']
 
 
 @require(native=requirements)

--- a/jarviscli/plugins/wiki.py
+++ b/jarviscli/plugins/wiki.py
@@ -12,10 +12,12 @@ class Wiki():
     enter wiki summary for getting summary of the topic
     wiki content for full page article of topic
     """
+
     def __call__(self, jarvis, s):
         k = s.split(' ', 1)
         if len(k) == 1:
-            jarvis.say("Do you mean:\n1. wiki search <subject>\n2. wiki summary <subject>\n3. wiki content <subject>")
+            jarvis.say(
+                "Do you mean:\n1. wiki search <subject>\n2. wiki summary <subject>\n3. wiki content <subject>")
         else:
             data = None
             if k[0] == "search":
@@ -51,7 +53,13 @@ class Wiki():
         except wikipedia.exceptions.DisambiguationError as error:
             return error.options[:5]
 
-    def content(self, title=None, pageid=None, auto_suggest=True, redirect=True, preload=False):
+    def content(
+            self,
+            title=None,
+            pageid=None,
+            auto_suggest=True,
+            redirect=True,
+            preload=False):
         """Returns plain text content of query's page, excluding images, tables and other data."""
         try:
             page = wikipedia.page(title)

--- a/jarviscli/plugins/write_agenda.py
+++ b/jarviscli/plugins/write_agenda.py
@@ -38,5 +38,5 @@ def read_agenda(jarvis, s):
         for row in reader:
             print(row)
         f.close()
-    except:
+    except BaseException:
         print('There is not an agenda')

--- a/jarviscli/tests/__init__.py
+++ b/jarviscli/tests/__init__.py
@@ -49,7 +49,8 @@ class MockJarvisAPI():
 
     def schedule(self, time_seconds, function, *args):
         self.notification_history.record(time_seconds, function, *args)
-        self.call_history.record('schedule', (time_seconds, function, args), None)
+        self.call_history.record(
+            'schedule', (time_seconds, function, args), None)
 
     def cancel(self, schedule_id):
         self.call_history.record('cancel', (), None)
@@ -96,9 +97,15 @@ class MockHistoryBuilder():
 
     def add_field(self, field):
         self._history._storage_by_field[field] = []
-        self._history.__dict__['contains_{}'.format(field)] = partial(self._history.contains, field)
-        self._history.__dict__['view_{}'.format(field)] = partial(self._history.view, field)
-        self._history.__dict__['last_{}'.format(field)] = partial(self._history.last, field)
+        self._history.__dict__[
+            'contains_{}'.format(field)] = partial(
+            self._history.contains, field)
+        self._history.__dict__[
+            'view_{}'.format(field)] = partial(
+            self._history.view, field)
+        self._history.__dict__[
+            'last_{}'.format(field)] = partial(
+            self._history.last, field)
         self._history._field_list.append(field)
         return self
 
@@ -115,6 +122,7 @@ class MockHistory():
     Note: For Methods with first parameter "field" method "name_field" exist.
     So "view('text')" can be rewritten as "view_text".
     """
+
     def __init__(self):
         self._storage_by_field = {}
         self._storage_by_index = []
@@ -127,7 +135,8 @@ class MockHistory():
         Do not call manually!
         """
         if len(self._field_list) != len(args):
-            raise ValueError("Argument count miss-match: {} --- {}".format(self._field_list, args))
+            raise ValueError(
+                "Argument count miss-match: {} --- {}".format(self._field_list, args))
         for i, field in enumerate(self._field_list):
             self._storage_by_field[field].append(args[i])
         self._storage_by_index.append(args)

--- a/jarviscli/tests/plugins/alias/plugin0123.py
+++ b/jarviscli/tests/plugins/alias/plugin0123.py
@@ -3,6 +3,7 @@ from plugin import Plugin
 
 class Plugin0(Plugin):
     """Test"""
+
     def require(self):
         pass
 
@@ -19,6 +20,7 @@ class Plugin0(Plugin):
 
 class Plugin3(Plugin):
     """Test"""
+
     def require(self):
         pass
 

--- a/jarviscli/tests/plugins/alias/plugin4567.py
+++ b/jarviscli/tests/plugins/alias/plugin4567.py
@@ -3,6 +3,7 @@ from plugin import Plugin
 
 class Plugin7(Plugin):
     """Test"""
+
     def require(self):
         pass
 

--- a/jarviscli/tests/plugins/composed/plugin0.py
+++ b/jarviscli/tests/plugins/composed/plugin0.py
@@ -3,6 +3,7 @@ from plugin import Plugin
 
 class Plugin0_Sub0(Plugin):
     """Doc"""
+
     def require(self):
         pass
 
@@ -18,6 +19,7 @@ class Plugin0_Sub0(Plugin):
 
 class Plugin3(Plugin):
     """Docu Plugin 3"""
+
     def require(self):
         pass
 
@@ -33,6 +35,7 @@ class Plugin3(Plugin):
 
 class Plugin0_Sub1__test(Plugin):
     """Doc"""
+
     def require(self):
         pass
 
@@ -49,6 +52,7 @@ class Plugin0_Sub1__test(Plugin):
 
 class Plugin2(Plugin):
     """Doc"""
+
     def require(self):
         pass
 
@@ -64,6 +68,7 @@ class Plugin2(Plugin):
 
 class Plugin3_Sub0(Plugin):
     """Docu Sub0"""
+
     def require(self):
         pass
 

--- a/jarviscli/tests/plugins/filter/native.py
+++ b/jarviscli/tests/plugins/filter/native.py
@@ -3,6 +3,7 @@ from plugin import Plugin
 
 class NativeTrue(Plugin):
     """Test"""
+
     def require(self):
         # ls should really be available on every system
         yield ("native", "ls")
@@ -19,6 +20,7 @@ class NativeTrue(Plugin):
 
 class NativeFalse(Plugin):
     """Test"""
+
     def require(self):
         yield ("native", "sdfsdefaerfsdfg")
 
@@ -34,6 +36,7 @@ class NativeFalse(Plugin):
 
 class NativeFalseAlt(Plugin):
     """Test"""
+
     def require(self):
         yield ("native", ("sdfsdefaerfsdfg", "ls"))
 

--- a/jarviscli/tests/plugins/filter/network.py
+++ b/jarviscli/tests/plugins/filter/network.py
@@ -4,6 +4,7 @@ from requests import ConnectionError
 
 class Network(Plugin):
     """Test"""
+
     def require(self):
         yield ("network", True)
 
@@ -19,6 +20,7 @@ class Network(Plugin):
 
 class NoNetwork(Plugin):
     """Test"""
+
     def require(self):
         pass
 
@@ -34,6 +36,7 @@ class NoNetwork(Plugin):
 
 class NoNetworkAlt(Plugin):
     """Test"""
+
     def require(self):
         yield ("network", False)
 

--- a/jarviscli/tests/plugins/filter/platform.py
+++ b/jarviscli/tests/plugins/filter/platform.py
@@ -3,6 +3,7 @@ from plugin import Plugin, LINUX, MACOS
 
 class Linux(Plugin):
     """Test"""
+
     def require(self):
         yield ("platform", LINUX)
 
@@ -18,6 +19,7 @@ class Linux(Plugin):
 
 class Macos(Plugin):
     """Test"""
+
     def require(self):
         yield ("platform", MACOS)
 
@@ -33,6 +35,7 @@ class Macos(Plugin):
 
 class Both(Plugin):
     """Test"""
+
     def require(self):
         yield ("platform", (LINUX, MACOS))
 
@@ -48,6 +51,7 @@ class Both(Plugin):
 
 class Bothalt(Plugin):
     """Test"""
+
     def require(self):
         yield ("platform", LINUX)
         yield ("platform", MACOS)

--- a/jarviscli/tests/plugins/filter/python.py
+++ b/jarviscli/tests/plugins/filter/python.py
@@ -3,6 +3,7 @@ from plugin import Plugin, PYTHON2, PYTHON3
 
 class PY2(Plugin):
     """Test"""
+
     def require(self):
         yield ("python", PYTHON2)
 
@@ -18,6 +19,7 @@ class PY2(Plugin):
 
 class PY3(Plugin):
     """Test"""
+
     def require(self):
         yield ("python", PYTHON3)
 
@@ -33,6 +35,7 @@ class PY3(Plugin):
 
 class Both(Plugin):
     """Test"""
+
     def require(self):
         yield ("python", (PYTHON2, PYTHON3))
 
@@ -48,6 +51,7 @@ class Both(Plugin):
 
 class Bothalt(Plugin):
     """Test"""
+
     def require(self):
         yield ("python", PYTHON2)
         yield ("python", PYTHON3)

--- a/jarviscli/tests/plugins/simple/plugin0.py
+++ b/jarviscli/tests/plugins/simple/plugin0.py
@@ -3,6 +3,7 @@ from plugin import Plugin
 
 class Plugin0(Plugin):
     """Doc"""
+
     def require(self):
         pass
 

--- a/jarviscli/tests/plugins/simple/plugin12.py
+++ b/jarviscli/tests/plugins/simple/plugin12.py
@@ -3,6 +3,7 @@ from plugin import Plugin
 
 class Plugin1(Plugin):
     """Test"""
+
     def require(self):
         pass
 
@@ -18,6 +19,7 @@ class Plugin1(Plugin):
 
 class Plugin2(Plugin):
     """Test"""
+
     def require(self):
         pass
 

--- a/jarviscli/tests/test_currencyconv.py
+++ b/jarviscli/tests/test_currencyconv.py
@@ -19,9 +19,10 @@ class CurrencyConvTest(PluginTest):
     @patch('plugins.currencyconv.input', return_value='Greece')
     def test_get_currency(self, get_mock):
         # normal case
-        self.assertEqual(self.test.get_currency('Enter a currency',
-                                                {'GREECE': 'EUR', 'EURO': 'EUR', 'BITCOINS': 'BTC'}
-                                                ), 'EUR')
+        self.assertEqual(
+            self.test.get_currency(
+                'Enter a currency', {
+                    'GREECE': 'EUR', 'EURO': 'EUR', 'BITCOINS': 'BTC'}), 'EUR')
 
     @patch('utilities.GeneralUtilities.input', return_value='1')
     def test_get_float_int(self, get_mock):

--- a/jarviscli/tests/test_forecast.py
+++ b/jarviscli/tests/test_forecast.py
@@ -70,11 +70,7 @@ class ForecastTest(PluginTest):
             get_mock.assert_called_with(
                 "http://api.openweathermap.org/data/2.5/forecast/daily?q={0}&cnt={1}"
                 "&APPID=ab6ec687d641ced80cc0c935f9dd8ac9&units={2}".format(
-                    my_city_and_country,
-                    '7',
-                    self.units['url_units']
-                )
-            )
+                    my_city_and_country, '7', self.units['url_units']))
 
     def test_header_as_expected_with_location(self):
         with patch.object(requests, 'get', return_value=MyResponse) as get_mock:
@@ -82,16 +78,13 @@ class ForecastTest(PluginTest):
             get_mock.assert_called_with(
                 "http://api.openweathermap.org/data/2.5/forecast/daily?q={0}&cnt={1}"
                 "&APPID=ab6ec687d641ced80cc0c935f9dd8ac9&units={2}".format(
-                    'New York',
-                    '7',
-                    self.units['url_units']
-                )
-            )
+                    'New York', '7', self.units['url_units']))
 
     def test_forecast_formatted_as_expected(self):
         with patch.object(requests, 'get', return_value=MyResponse) as _:
             self.test.run('Some location')
-            last_call = "\tMin temperature: {} {}".format('17.0', self.units['str_units'])
+            last_call = "\tMin temperature: {} {}".format(
+                '17.0', self.units['str_units'])
             third_call = "\tWeather: {}".format('Clear')
 
             self.assertEqual(last_call, self.history_say().last_text())

--- a/jarviscli/tests/test_lyrics.py
+++ b/jarviscli/tests/test_lyrics.py
@@ -23,8 +23,10 @@ class Lyrics_Test(PluginTest):
                          "you forgot to add either song name or artist name")
 
     def test_lyrics_not_found_given_wrong_parameter(self):
-        self.assertEqual(self.module.find(self.wrong_info),
-                         "Song or Singer does not exist or the API does not have lyrics")
+        self.assertEqual(
+            self.module.find(
+                self.wrong_info),
+            "Song or Singer does not exist or the API does not have lyrics")
 
     def test_split_works(self):
         self.assertEqual(self.module.parse(self.complete_info), [

--- a/jarviscli/tests/test_music.py
+++ b/jarviscli/tests/test_music.py
@@ -16,7 +16,9 @@ class MusicTest(PluginTest):
     def test_song_is_searched_with_the_given_song_name(self):
         first_popen_call = call("ls music -tc")
         first_system_call = call(
-            "cd music && instantmusic -s '" + self.song_name + "' 2> /dev/null")
+            "cd music && instantmusic -s '" +
+            self.song_name +
+            "' 2> /dev/null")
         with patch.object(os, 'system', return_value=None) as mock_system:
             with patch.object(os, 'popen', return_value=os.popen("")) as mock_popen:
                 self.music.run(self.song_name)

--- a/jarviscli/tests/test_music.py
+++ b/jarviscli/tests/test_music.py
@@ -16,9 +16,9 @@ class MusicTest(PluginTest):
     def test_song_is_searched_with_the_given_song_name(self):
         first_popen_call = call("ls music -tc")
         first_system_call = call(
-            "cd music && instantmusic -s '" +
-            self.song_name +
-            "' 2> /dev/null")
+            "cd music && instantmusic -s '"
+            + self.song_name
+            + "' 2> /dev/null")
         with patch.object(os, 'system', return_value=None) as mock_system:
             with patch.object(os, 'popen', return_value=os.popen("")) as mock_popen:
                 self.music.run(self.song_name)

--- a/jarviscli/tests/test_quote.py
+++ b/jarviscli/tests/test_quote.py
@@ -8,11 +8,15 @@ from tests import PluginTest
 
 class QuoteTest(PluginTest):
 
-    quotes = [{u'quote': (u'Traveling, you realize that differences are lost:'
-                          ' each city takes to resembling all cities, places exchange'
-                          ' their form, order, distances, a shapeless dust cloud invades'
-                          ' the continents.'),
-               u'cat': u'travel', u'author': 'Italo Calvino'}]
+    quotes = [
+        {
+            u'quote': (
+                u'Traveling, you realize that differences are lost:'
+                ' each city takes to resembling all cities, places exchange'
+                ' their form, order, distances, a shapeless dust cloud invades'
+                ' the continents.'),
+            u'cat': u'travel',
+            u'author': 'Italo Calvino'}]
 
     def setUp(self):
         self.test = self.load_plugin(Quote)

--- a/jarviscli/utilities/dateTime.py
+++ b/jarviscli/utilities/dateTime.py
@@ -18,5 +18,6 @@ class WeekDay(object):
 
     def get_week_from_today(self):
         day_ind = self.today.isoweekday()
-        reordered_week = self.day_tags[day_ind - 1:] + self.day_tags[:day_ind - 1]
+        reordered_week = self.day_tags[day_ind -
+                                       1:] + self.day_tags[:day_ind - 1]
         return reordered_week

--- a/jarviscli/utilities/dateTime.py
+++ b/jarviscli/utilities/dateTime.py
@@ -18,6 +18,6 @@ class WeekDay(object):
 
     def get_week_from_today(self):
         day_ind = self.today.isoweekday()
-        reordered_week = self.day_tags[day_ind -
-                                       1:] + self.day_tags[:day_ind - 1]
+        reordered_week = self.day_tags[day_ind
+                                       - 1:] + self.day_tags[:day_ind - 1]
         return reordered_week

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -26,6 +26,7 @@ class Voice:
     DOCUMENTATION on pyttsx3:
         https://pyttsx3.readthedocs.io/en/latest/
     """
+
     def speak(self, first_run):
         """
         This method must be invoked whenever Jarvis is ready to
@@ -88,5 +89,6 @@ class VoiceNotSupported(Voice):
 
     def text_to_speech(self, speech):
         if not self.warning_print:
-            print("Speech not supported! Please install pyttsx3 text-to-speech engine (sapi5, nsss or espeak)")
+            print(
+                "Speech not supported! Please install pyttsx3 text-to-speech engine (sapi5, nsss or espeak)")
             self.warning_print = True


### PR DESCRIPTION
```
find . -iname "*.py" -not -path "./env/**" | xargs autopep8 --in-place --aggressive --aggressive
```

- using [autopep8](https://github.com/hhatto/autopep8) to automatically format to PEP8 style
- Ignoring W503, W504 PEP errors in travis CI

