### PR TITLE
Let Jarvis run commands directly from the terminal  #519

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -54,7 +54,8 @@ class JarvisAPI(object):
         # return without newline
         return text.rstrip()
 
-    def input_number(self, prompt="", color="", rtype=float, rmin=None, rmax=None):
+    def input_number(self, prompt="", color="",
+                     rtype=float, rmin=None, rmax=None):
         """
         Get user input: As number.
 
@@ -69,8 +70,10 @@ class JarvisAPI(object):
         while True:
             try:
                 value = rtype(self.input(prompt, color).replace(',', '.'))
-                if (rmin is not None and value < rmin) or (rmax is not None and value > rmax):
-                    prompt = "Sorry, needs to be between {} and {}. Try again: ".format(rmin, ramx)
+                if (rmin is not None and value < rmin) or (
+                        rmax is not None and value > rmax):
+                    prompt = "Sorry, needs to be between {} and {}. Try again: ".format(
+                        rmin, ramx)
                 else:
                     return value
             except ValueError:
@@ -307,6 +310,10 @@ class CmdInterpreter(Cmd):
     def completedefault(self, text, line, begidx, endidx):
         """Default completion"""
         return [i for i in self.actions if i.startswith(text)]
+
+    def execute_once(self, command):
+        self.get_api().eval(command)
+        self.close()
 
     def error(self):
         """Jarvis let you know if an error has occurred."""

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -54,8 +54,7 @@ class JarvisAPI(object):
         # return without newline
         return text.rstrip()
 
-    def input_number(self, prompt="", color="",
-                     rtype=float, rmin=None, rmax=None):
+    def input_number(self, prompt="", color="", rtype=float, rmin=None, rmax=None):
         """
         Get user input: As number.
 
@@ -70,10 +69,8 @@ class JarvisAPI(object):
         while True:
             try:
                 value = rtype(self.input(prompt, color).replace(',', '.'))
-                if (rmin is not None and value < rmin) or (
-                        rmax is not None and value > rmax):
-                    prompt = "Sorry, needs to be between {} and {}. Try again: ".format(
-                        rmin, ramx)
+                if (rmin is not None and value < rmin) or (rmax is not None and value > rmax):
+                    prompt = "Sorry, needs to be between {} and {}. Try again: ".format(rmin, ramx)
                 else:
                     return value
             except ValueError:

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -166,14 +166,18 @@ class Jarvis(CmdInterpreter, object):
                 break
         return output
 
-    def executor(self):
+    def executor(self, command):
         """
-        This method is opening a terminal session with the user.
+        If command is not empty, we execute it and terminate.
+        Else, this method opens a terminal session with the user.
         We can say that it is the core function of this whole class
         and it joins all the function above to work together like a
         clockwork. (Terminates when the user send the "exit", "quit"
         or "goodbye command")
         :return: Nothing to return.
         """
-        self.speak()
-        self.cmdloop(self.first_reaction_text)
+        if command:
+            self.execute_once(command)
+        else:
+            self.speak()
+            self.cmdloop(self.first_reaction_text)

--- a/jarviscli/__main__.py
+++ b/jarviscli/__main__.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import Jarvis
+from sys import argv
 
 
 def main():
     jarvis = Jarvis.Jarvis()
-    jarvis.executor()
+    command = " ".join(argv[1:]).strip()
+    jarvis.executor(command)
 
 
 if __name__ == '__main__':

--- a/setup.sh
+++ b/setup.sh
@@ -40,16 +40,16 @@ exec 3<> jarvis
 
       case ${answer:0:1} in
       2 )
-          echo "python $jarvispath/jarviscli/" >&3
+          echo "python $jarvispath/jarviscli/ \$*" >&3
       ;;
       * )
-          echo "python3 $jarvispath/jarviscli/" >&3
+          echo "python3 $jarvispath/jarviscli/ \$*" >&3
       ;;
       esac
 
     else
       echo "source $jarvispath/env/bin/activate" >&3
-      echo "python $jarvispath/jarviscli/" >&3
+      echo "python $jarvispath/jarviscli/ \$*" >&3
     fi
 
 exec 3>&-


### PR DESCRIPTION
Calling Jarvis with a command-line argument now starts an execution mode which attempts to run that argument as a command and terminates.

setup.sh was modified to generate a `/jarvis` file which that handles command-line arguments, so the setup must be re-run in order for the new feature to work. 
