### PR TITLE
add support for all platforms in plugin manager

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -74,20 +74,20 @@ Plugins, which are non compatible are ignored and will not be displayed.
 Current available requirements:
 
 * Network: (True, False)
-* Plattform: (plugin.LINUX, plugin.MACOS)
+* Platform: (plugin.LINUX, plugin.MACOS, plugin.WINDOWS, plugin.UNIX - equals plugin.LINUX + plugin.MACOS)
 * Python: (plugin.PYTHON2, plugin.PYTHON3)
 * Native: (any string)
 
 Native means any native Binary in $PATH must exist. If multiple natives are specified (unlike other requirements) ALL must be fulfilled.
 
-Example: Only support Python 3 with Linux; Require firefox and curl with active network connection.
+Example: Only support Python 3 with Linux or Windows; Require firefox and curl with active network connection.
 
 
 ```
-from plugin import plugin, require, PYTHON3, LINUX
+from plugin import plugin, require, PYTHON3, LINUX, WINDOWS
 
 
-@require(platform=LINUX, python=PYTHON3, network=True, native=["firefox", "curl"])
+@require(platform=[LINUX, WINDOWS], python=PYTHON3, network=True, native=["firefox", "curl"])
 @plugin("helloworld")
 def helloWorld(jarvis, s):
     (...)
@@ -95,7 +95,7 @@ def helloWorld(jarvis, s):
 
 Special behaviour:
 
-* If a plugin is incompabible because of missing native binary (and because of natives only), an notification shall be printed.
+* If a plugin is incompatible because of missing native binary (and because of natives only), an notification shall be printed.
 * If network=True is required, you won't need to try-catch requests.ConnectionError - this error is auto-cached with connection-error
 
 

--- a/jarviscli/PluginManager.py
+++ b/jarviscli/PluginManager.py
@@ -193,8 +193,12 @@ class PluginDependency(object):
             self._requirement_python = plugin.PYTHON3
         if sys.platform == "darwin":
             self._requirement_platform = plugin.MACOS
-        else:
+        elif sys.platform == "win32":
+            self._requirement_platform = plugin.WINDOWS
+        elif sys.platform.startswith("linux"):
             self._requirement_platform = plugin.LINUX
+        else:
+            self._requirement_platform = plugin.UNSUPPORTED
 
     def _plugin_get_requirements(self, requirements_iter):
         plugin_requirements = {

--- a/jarviscli/PluginManager.py
+++ b/jarviscli/PluginManager.py
@@ -198,7 +198,8 @@ class PluginDependency(object):
         elif sys.platform.startswith("linux"):
             self._requirement_platform = plugin.LINUX
         else:
-            self._requirement_platform = plugin.UNSUPPORTED
+            self._requirement_platform = None
+            warning("Unsupported platform {}".format(sys.platform))
 
     def _plugin_get_requirements(self, requirements_iter):
         plugin_requirements = {
@@ -249,6 +250,9 @@ class PluginDependency(object):
     def _check_platform(self, values):
         if not values:
             return True
+
+        if plugin.UNIX in values:
+            values += [plugin.LINUX, plugin.MACOS]
 
         return self._requirement_platform in values
 

--- a/jarviscli/plugin.py
+++ b/jarviscli/plugin.py
@@ -12,7 +12,8 @@ PYTHON3 = "PY3"
 MACOS = "MACOS"
 LINUX = "LINUX"
 WINDOWS = "WINDOWS"
-UNSUPPORTED = "UNSUPPORTED"
+# Shortcut for MACOS + LINUX
+UNIX = "UNIX"
 
 
 def plugin(name):

--- a/jarviscli/plugin.py
+++ b/jarviscli/plugin.py
@@ -11,6 +11,8 @@ PYTHON3 = "PY3"
 # platform
 MACOS = "MACOS"
 LINUX = "LINUX"
+WINDOWS = "WINDOWS"
+UNSUPPORTED = "UNSUPPORTED"
 
 
 def plugin(name):


### PR DESCRIPTION
I tried to add all supported platforms. I don't know if UNSUPPORTED is a good idea, because we will never call @require(platform=UNSUPPORTED).
ALso, till UNIX is implemented, 
```
@require(platform=LINUX)
@require(platform=WINDOWS)
```
works fine, but 
```
@require(platform=LINUX, platform=WINDOWS)
```
gives error.
