### PR TITLE
Issue#542: For MacOs escape speech text for better command line friendly.

### DIFF
--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -32,7 +32,8 @@ def create_voice():
 
 class VoiceMac():
     def text_to_speech(self, speech):
-        system('say {}'.format(speech))
+        speech = speech.replace("'", "\\'")
+        system('say $\'{}\''.format(speech))
 
 
 class VoiceLinux():


### PR DESCRIPTION
Please review and merge my changes for issue#542

Changes include, quoting the speech text and escaping the speech text for better command line friendly ness.

I tested in MacOs, with  following text and I don't see any errors.
`Do you want $100 million? Enter ('yes'/"no"):`

Suggest any more tests if required.