### PR TITLE
Added a whoami feature that also supports getting more information

### DIFF
--- a/jarviscli/plugins/whoami.py
+++ b/jarviscli/plugins/whoami.py
@@ -1,0 +1,56 @@
+import os
+import re
+from plugin import plugin, require, LINUX
+
+@require(native="id")
+@require(platform=LINUX)
+@plugin("whoami")
+def whoami(jarvis, s):
+	"""
+	Tells you the current user name
+	whoami:          says the current effective user ID's name
+	whoami -options: passes the options to the linux
+	                 command "id" and returns the response
+	"""
+	
+	def check(s) -> bool:
+		"""
+		Ensure that the string is not damaging
+		"""
+		
+		options = [
+			"--context",
+			"--group",
+			"--groups",
+			"--name",
+			"--real",
+			"--user",
+			"--zero",
+			"--help",
+			"--version"
+		]
+		
+		for i in s.split(" "):
+			if (
+				# valid POSIX user names or UIDs
+				not re.match("(^[a-z][a-z0-9-]*$)|(^[0-9]+$)", i)
+				and
+				# possible short options
+				not re.match("^-[agnruzGZ]+$", i)
+				and
+				# possible long options
+				i not in options
+			):
+				return False
+		
+		return True
+	
+	if s == "":
+		os.system("id -un")
+		return
+	
+	if not check(s):
+		jarvis.say("There seems to be some awkward stuff ...?")
+		return
+	
+	os.system("id " + str(s))

--- a/jarviscli/plugins/whoami.py
+++ b/jarviscli/plugins/whoami.py
@@ -55,4 +55,3 @@ def whoami(jarvis, s):
         return
 
     os.system("id " + str(s))
-

--- a/jarviscli/plugins/whoami.py
+++ b/jarviscli/plugins/whoami.py
@@ -2,55 +2,57 @@ import os
 import re
 from plugin import plugin, require, LINUX
 
+
 @require(native="id")
 @require(platform=LINUX)
 @plugin("whoami")
 def whoami(jarvis, s):
-	"""
-	Tells you the current user name
-	whoami:          says the current effective user ID's name
-	whoami -options: passes the options to the linux
-	                 command "id" and returns the response
-	"""
-	
-	def check(s) -> bool:
-		"""
-		Ensure that the string is not damaging
-		"""
-		
-		options = [
-			"--context",
-			"--group",
-			"--groups",
-			"--name",
-			"--real",
-			"--user",
-			"--zero",
-			"--help",
-			"--version"
-		]
-		
-		for i in s.split(" "):
-			if (
-				# valid POSIX user names or UIDs
-				not re.match("(^[a-z][a-z0-9-]*$)|(^[0-9]+$)", i)
-				and
-				# possible short options
-				not re.match("^-[agnruzGZ]+$", i)
-				and
-				# possible long options
-				i not in options
-			):
-				return False
-		
-		return True
-	
-	if s == "":
-		os.system("id -un")
-		return
-	
-	if not check(s):
-		jarvis.say("There seems to be some awkward stuff ...?")
-		return
-	
-	os.system("id " + str(s))
+    """
+    Tells you the current user name
+    whoami:          says the current effective user ID's name
+    whoami -options: passes the options to the linux
+    command "id" and returns the response
+    """
+
+    def check(s) -> bool:
+        """
+        Ensure that the string is not damaging
+        """
+
+        options = [
+            "--context",
+            "--group",
+            "--groups",
+            "--name",
+            "--real",
+            "--user",
+            "--zero",
+            "--help",
+            "--version"
+        ]
+
+        for i in s.split(" "):
+            if (
+                # valid POSIX user names or UIDs
+                not re.match("(^[a-z][a-z0-9-]*$)|(^[0-9]+$)", i)
+                and
+                # possible short options
+                not re.match("^-[agnruzGZ]+$", i)
+                and
+                # possible long options
+                i not in options
+            ):
+                return False
+
+        return True
+
+    if s == "":
+        os.system("id -un")
+        return
+
+    if not check(s):
+        jarvis.say("There seems to be some awkward stuff ...?")
+        return
+
+    os.system("id " + str(s))
+


### PR DESCRIPTION
I've implemented a feature that let's you get your username (like the command `whoami` in linux) but also supports additional options passed to the binary `id` in the background. To avoid possible security breaches, the input is checked against regular expressions or valid options.

So, one can do the following:
```
~> Hi, what can I do for you?
whoami
root
~> What can i do for you?
whoami --help
Usage: id [OPTION]... [USER]
Print user and group information for the specified USER,
or (when USER omitted) for the current user.

  -a             ignore, for compatibility with other versions
  -Z, --context  print only the security context of the process
  -g, --group    print only the effective group ID
  -G, --groups   print all group IDs
  -n, --name     print a name instead of a number, for -ugG
  -r, --real     print the real ID instead of the effective ID, with -ugG
  -u, --user     print only the effective user ID
  -z, --zero     delimit entries with NUL characters, not whitespace;
                   not permitted in default format
      --help     display this help and exit
      --version  output version information and exit

Without any OPTION, print some useful set of identified information.

GNU coreutils online help: <http://www.gnu.org/software/coreutils/>
Report id translation bugs to <http://translationproject.org/team/>
Full documentation at: <http://www.gnu.org/software/coreutils/id>
or available locally via: info '(coreutils) id invocation'
~> What can i do for you?
whoami -G
0
~> Hi, what can I do for you?
whoami 33
uid=33(www-data) gid=33(www-data) groups=33(www-data)
~> What can i do for you?
whoami games
uid=5(games) gid=60(games) groups=60(games)
```
