### PR TITLE
Added speak argument to jarvis.say

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -15,7 +15,7 @@ in the utilities-package should be implemented here.
 
 ## say
 ```python
-JarvisAPI.say(self, text, color='')
+JarvisAPI.say(self, text, color='', speak=True)
 ```
 
 This method give the jarvis the ability to print a text
@@ -23,6 +23,7 @@ and talk when sound is enable.
 :param text: the text to print (or talk)
 :param color: for text - use colorama (https://pypi.org/project/colorama/)
               e.g. Fore.BLUE
+:param speak: False, if text shouldn't be spoken even if speech is enabled
 
 ## input
 ```python

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -31,16 +31,18 @@ class JarvisAPI(object):
     def __init__(self, jarvis):
         self._jarvis = jarvis
 
-    def say(self, text, color=""):
+    def say(self, text, color="", speak=True):
         """
         This method give the jarvis the ability to print a text
         and talk when sound is enable.
         :param text: the text to print (or talk)
         :param color: for text - use colorama (https://pypi.org/project/colorama/)
                       e.g. Fore.BLUE
+        :param speak: False, if text shouldn't be spoken even if speech is enabled
         """
-        self._jarvis.speak(text)
         print(color + text + Fore.RESET)
+        if speak:
+            self._jarvis.speak(text)
 
     def input(self, prompt="", color=""):
         """


### PR DESCRIPTION
Added optional bool `speak` argument to control whether text should be spoken or not (to avoid jarvis speaking out long texts, tables or things like ASCII art).
Closes #588 