### PR TITLE
Initial battery plugin implementation without upower

### DIFF
--- a/jarviscli/PluginManager.py
+++ b/jarviscli/PluginManager.py
@@ -259,7 +259,13 @@ class PluginDependency(object):
     def _check_native(self, values, plugin):
         missing = ""
         for native in values:
-            if not executable_exists(native):
+            if native.startswith('!'):
+                # native should not exist
+                requirement_ok = not executable_exists(native[1:])
+            else:
+                requirement_ok = executable_exists(native)
+
+            if not requirement_ok:
                 missing += native
                 missing += " "
 

--- a/jarviscli/plugins/battery.py
+++ b/jarviscli/plugins/battery.py
@@ -107,8 +107,16 @@ def battery_LINUX_FALLBACK(jarvis, s):
 
     # Get the battery info
     # https://askubuntu.com/a/309146
-    battery_dir = "/sys/class/power_supply/BAT0/"
+    battery_dir = False
+    for bat_num in range(10):
+        battery_dir_check = "/sys/class/power_supply/BAT{}/".format(str(bat_num))
+        if os.path.exists(battery_dir_check):
+            battery_dir = battery_dir_check
+            break
 
+    if battery_dir is False:
+        jarvis.say("No Battery found!")
+        return
 
     def get_battery_info(info):
         return subprocess.check_output(["cat", battery_dir + info]).decode("utf-8")[:-1]


### PR DESCRIPTION
Adds a fallback for Linux systems without upower using [this](https://askubuntu.com/a/309146).