### PR TITLE
working directory should be returned back to original state after test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,3 +11,4 @@ echo "checking for unit test"
 python3 -m unittest discover
 echo "unit tests checked"
 echo ""
+cd ..


### PR DESCRIPTION
added cd .. at the end of the file test.sh to send back to original working directory after the test is complete
now due to the `cd jarviscli/` command the cursor stays at the folder jarviscli folder even if the test is complete
