### PR TITLE
New Plugin: Geocoding

### DIFF
--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -6,7 +6,6 @@ from colorama import Fore
 from plugin import alias, plugin, require
 
 
-@alias('geocoder')
 @require(network=True)
 @plugin('geocode')
 class Geocoder:

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -20,6 +20,8 @@ class Geocoder:
         A street address input by the user
     cleaned_addr : str
         A street address cleaned for use in a URL
+    output : dict of str: str 
+        Parsed results from the API request if a match was found
     help_prompt : str
         A description of this tool that the user can directly access from
         within the plugin
@@ -27,6 +29,7 @@ class Geocoder:
     jarvis = None
     input_addr = None
     cleaned_addr = None
+    output = None
     help_prompt = ("Geocoding converts street addresses to geographic"
                    " latitude and longitude. To use this tool, you can enter a"
                    " street address in this form: STREET NUMBER STREET NAME, CITY,"
@@ -63,12 +66,12 @@ class Geocoder:
 
         # Request succeeded
         else:
-            output = self.parse_request(req)
+            self.output = self.parse_request(req)
 
-            if output:
-                for result in output:
+            if self.output:
+                for result in self.output:
                     self.jarvis.say("{}: {}".format(result,
-                                                    output[result]),
+                                                    self.output[result]),
                                     Fore.CYAN)
 
             else:

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -10,6 +10,21 @@ from plugin import alias, plugin, require
 @require(network=True)
 @plugin('geocode')
 class Geocoder:
+    """
+    Geocoding tool to convert street addresses to latitude and longitude.
+
+    Attributes
+    ----------
+    jarvis : CmdInterpreter.JarvisAPI
+        An instance of Jarvis that will be used to interact with the user
+    input_addr : str
+        A street address input by the user
+    cleaned_addr : str
+        A street address cleaned for use in a URL
+    help_prompt : str
+        A description of this tool that the user can directly access from
+        within the plugin
+    """
     jarvis = None
     input_addr = None
     cleaned_addr = None

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -50,7 +50,7 @@ class Geocoder:
         # Required disclaimer per API terms of service
         self.jarvis.say("Disclaimer: This product uses the Census Bureau Data"
                         " API but is not endorsed or certified by the Census"
-                        "Bureau.", Fore.LIGHTBLACK_EX)
+                        " Bureau.", Fore.LIGHTBLACK_EX)
 
         self.input_addr = self.get_input_addr(s)
         self.cleaned_addr = self.clean_addr(self.input_addr)

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -1,0 +1,67 @@
+import json
+import re
+import requests
+import requests.exceptions
+from colorama import Fore
+from plugin import plugin, require
+
+
+@require(network=True)
+@plugin('geocode')
+def geocode(jarvis, s):
+    jarvis.say("Welcome to geocoder. I can use geocoding to convert a street address to a geographic latitude and longitude.", Fore.RED)
+
+    # If an address wasn't given when the plugin is launched
+    if not s:
+        s = jarvis.input("Enter the full street address to geocode: ")
+    # Parse the address to remove url-unfriendly characters
+    parsed_addr = parse_address(s)
+
+    url = "https://geocoding.geo.census.gov/geocoder/locations/onelineaddress?address={}&benchmark=4&vintage=4&format=json".format(parsed_addr)
+
+    # Make request to geocoding API
+    req = make_request(url)
+
+    # Request failed
+    if not req:
+        jarvis.say("The geocoding service appears to be unavailable. Please try again later.", Fore.RED)
+    
+    # Request succeeded
+    else:
+        data = json.loads(req.text)
+        matches = data['result']['addressMatches']
+
+        if matches:
+            if len(matches) > 1:
+                jarvis.say("Multiple address matches were found. Showing best match.", Fore.YELLOW)
+
+            match = data['result']['addressMatches'][0]
+
+            output = {'Address matched': match['matchedAddress'],
+                    'Latitude': str(match['coordinates']['y']),
+                    'Longitude': str(match['coordinates']['x'])}
+
+            for result in output:
+                jarvis.say("{}: {}".format(result, output[result]), Fore.CYAN)
+
+        else:
+            jarvis.say('No matching addresses found.', Fore.RED)
+
+def parse_address(s):
+    # Remove everything that isn't alphanumeric or whitespace
+    s = re.sub(r"[^\w\s]", '', s)
+
+    # Replace all whitespace
+    s = re.sub(r"\s+", '+', s)
+
+    return s
+
+
+# Make a request to a URL. Return the request if success or None if it failed
+def make_request(url):
+    try:
+        req = requests.get(url)
+        req.raise_for_status()
+        return req
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.exceptions.HTTPError):
+        return None

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -30,7 +30,7 @@ class Geocoder:
             An instance of Jarvis that will be used to interact with the user
         s : str
             The input string that was submitted when the plugin was launched.
-            Likely to be empty. 
+            Likely to be empty.
         """
         self.jarvis = jarvis
         self.input_addr = self.get_input_addr(s)
@@ -63,7 +63,7 @@ class Geocoder:
         Returns:
         -------
         str
-            URL for the geocoding API using the input address 
+            URL for the geocoding API using the input address
         """
         return ("https://geocoding.geo.census.gov/geocoder/locations/"
                 "onelineaddress?address={}&benchmark=Public_AR_Current&format="
@@ -80,7 +80,7 @@ class Geocoder:
         ----------
         s : str
             The input string that was submitted when the plugin was launched.
-            Likely to be empty. 
+            Likely to be empty.
 
         Returns:
         -------
@@ -121,7 +121,7 @@ class Geocoder:
         return s
 
     def get_request(self):
-        """Make a request to the geocoding API and return the request 
+        """Make a request to the geocoding API and return the request
         if it succeeds
 
         Returns:

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -14,11 +14,11 @@ class Geocoder:
     input_addr = None
     cleaned_addr = None
     help_prompt = ("Geocoding converts street addresses to geographic"
-        " latitude and longitude. To use this tool, you can enter a"
-        " street address in this form: STREET NUMBER STREET NAME, CITY,"
-        " STATE, ZIP. For example: 1000 Main Street, Los Angeles, CA,"
-        " 90012. Currently, this tool only works for addresses in the"
-        " United States.")
+                   " latitude and longitude. To use this tool, you can enter a"
+                   " street address in this form: STREET NUMBER STREET NAME, CITY,"
+                   " STATE, ZIP. For example: 1000 Main Street, Los Angeles, CA,"
+                   " 90012. Currently, this tool only works for addresses in the"
+                   " United States.")
 
     def __call__(self, jarvis, s):
         """Run the geocoding tool by getting an address from the user, passing
@@ -40,17 +40,17 @@ class Geocoder:
         # Request failed
         if not req:
             self.jarvis.say("The geocoding service appears to be unavailable."
-                " Please try again later.", Fore.RED)
-        
+                            " Please try again later.", Fore.RED)
+
         # Request succeeded
         else:
             output = self.parse_request(req)
 
             if output:
                 for result in output:
-                    self.jarvis.say("{}: {}".format(result, 
-                        output[result]), 
-                        Fore.CYAN)
+                    self.jarvis.say("{}: {}".format(result,
+                                                    output[result]),
+                                    Fore.CYAN)
 
             else:
                 self.jarvis.say("No matching addresses found.", Fore.RED)
@@ -66,8 +66,8 @@ class Geocoder:
             URL for the geocoding API using the input address 
         """
         return ("https://geocoding.geo.census.gov/geocoder/locations/"
-            "onelineaddress?address={}&benchmark=Public_AR_Current&format="
-            "json".format(self.cleaned_addr))
+                "onelineaddress?address={}&benchmark=Public_AR_Current&format="
+                "json".format(self.cleaned_addr))
 
     def help(self):
         """Print the help prompt for the plugin"""
@@ -90,7 +90,7 @@ class Geocoder:
         while True:
             if not s:
                 s = self.jarvis.input("Enter the full street address to"
-                    " geocode (or type help for options): ") 
+                                      " geocode (or type help for options): ")
 
             if s.lower() == 'help':
                 self.help()
@@ -135,9 +135,9 @@ class Geocoder:
             # Raise HTTPErrors if encountered
             req.raise_for_status()
             return req
-        except (requests.exceptions.ConnectionError, 
-            requests.exceptions.Timeout, 
-            requests.exceptions.HTTPError):
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                requests.exceptions.HTTPError):
             return None
 
     def parse_request(self, req):
@@ -158,13 +158,13 @@ class Geocoder:
         """
         data = json.loads(req.text)
         matches = data['result']['addressMatches']
-        
+
         if matches:
             best_match = matches[0]
 
             output = {'Address matched': best_match['matchedAddress'],
-                    'Latitude': str(best_match['coordinates']['y']),
-                    'Longitude': str(best_match['coordinates']['x'])}
+                      'Latitude': str(best_match['coordinates']['y']),
+                      'Longitude': str(best_match['coordinates']['x'])}
 
         else:
             output = None

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -47,6 +47,11 @@ class Geocoder:
             Likely to be empty.
         """
         self.jarvis = jarvis
+        # Required disclaimer per API terms of service
+        self.jarvis.say("Disclaimer: This product uses the Census Bureau Data"
+                        " API but is not endorsed or certified by the Census"
+                        "Bureau.", Fore.LIGHTBLACK_EX)
+
         self.input_addr = self.get_input_addr(s)
         self.cleaned_addr = self.clean_addr(self.input_addr)
         req = self.get_request()

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -3,7 +3,7 @@ import re
 import requests
 import requests.exceptions
 from colorama import Fore
-from plugin import alias, plugin, require
+from plugin import plugin, require
 
 
 @require(network=True)

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -20,8 +20,10 @@ class Geocoder:
         A street address input by the user
     cleaned_addr : str
         A street address cleaned for use in a URL
-    output : dict of str: str 
+    output : dict of str: str
         Parsed results from the API request if a match was found
+    req : request.Request
+        Geocoding request returned by API if API could be accessed
     help_prompt : str
         A description of this tool that the user can directly access from
         within the plugin
@@ -30,6 +32,7 @@ class Geocoder:
     input_addr = None
     cleaned_addr = None
     output = None
+    req = None
     help_prompt = ("Geocoding converts street addresses to geographic"
                    " latitude and longitude. To use this tool, you can enter a"
                    " street address in this form: STREET NUMBER STREET NAME, CITY,"
@@ -57,16 +60,16 @@ class Geocoder:
 
         self.input_addr = self.get_input_addr(s)
         self.cleaned_addr = self.clean_addr(self.input_addr)
-        req = self.get_request()
+        self.req = self.get_request()
 
         # Request failed
-        if not req:
+        if not self.req:
             self.jarvis.say("The geocoding service appears to be unavailable."
                             " Please try again later.", Fore.RED)
 
         # Request succeeded
         else:
-            self.output = self.parse_request(req)
+            self.output = self.parse_request(self.req)
 
             if self.output:
                 for result in self.output:

--- a/jarviscli/plugins/geocode.py
+++ b/jarviscli/plugins/geocode.py
@@ -54,37 +54,6 @@ class Geocoder:
 
             else:
                 self.jarvis.say("No matching addresses found.", Fore.RED)
-    
-    def parse_request(self, req):
-        """Parse a request returned by the geocoding API to extract all
-        relevant geocoding data
-
-        Parameters
-        ----------
-        req : request.Request
-            The Request object returned by the geocoding API for an address
-            search
-
-        Returns:
-        -------
-        dict of str: str
-            A dictionary of geocoding results for the best matched address
-            from the request
-        """
-        data = json.loads(req.text)
-        matches = data['result']['addressMatches']
-        
-        if matches:
-            best_match = matches[0]
-
-            output = {'Address matched': best_match['matchedAddress'],
-                    'Latitude': str(best_match['coordinates']['y']),
-                    'Longitude': str(best_match['coordinates']['x'])}
-
-        else:
-            output = None
-
-        return output
 
     @property
     def url(self):
@@ -94,11 +63,15 @@ class Geocoder:
         Returns:
         -------
         str
-            URL to geocode the input address 
+            URL for the geocoding API using the input address 
         """
         return ("https://geocoding.geo.census.gov/geocoder/locations/"
             "onelineaddress?address={}&benchmark=Public_AR_Current&format="
             "json".format(self.cleaned_addr))
+
+    def help(self):
+        """Print the help prompt for the plugin"""
+        self.jarvis.say(self.help_prompt, Fore.BLUE)
 
     def get_input_addr(self, s):
         """Get an input address from the user and handle help commands
@@ -124,10 +97,6 @@ class Geocoder:
                 s = None
             else:
                 return s.lower()
-
-    def help(self):
-        """Print the help prompt for the plugin"""
-        self.jarvis.say(self.help_prompt, Fore.BLUE)
 
     def clean_addr(self, s):
         """Reformat a string to be URL friendly
@@ -170,3 +139,34 @@ class Geocoder:
             requests.exceptions.Timeout, 
             requests.exceptions.HTTPError):
             return None
+
+    def parse_request(self, req):
+        """Parse a request returned by the geocoding API to extract all
+        relevant geocoding data
+
+        Parameters
+        ----------
+        req : request.Request
+            The Request object returned by the geocoding API for an address
+            search
+
+        Returns:
+        -------
+        dict of str: str
+            A dictionary of geocoding results for the best matched address
+            from the request
+        """
+        data = json.loads(req.text)
+        matches = data['result']['addressMatches']
+        
+        if matches:
+            best_match = matches[0]
+
+            output = {'Address matched': best_match['matchedAddress'],
+                    'Latitude': str(best_match['coordinates']['y']),
+                    'Longitude': str(best_match['coordinates']['x'])}
+
+        else:
+            output = None
+
+        return output


### PR DESCRIPTION
This is a plugin that allows Jarvis to geocode, converting street addresses to latitude and longitude coordinates. This is done using the public geocoding API provided by the US Census Bureau.