### PR TITLE
Implement #651: Store 'sound enabled' setting

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -32,6 +32,8 @@ class JarvisAPI(object):
     def __init__(self, jarvis):
         self._jarvis = jarvis
         self.spinner_running = False
+        # Remember if voice is currently enabled or not
+        self._jarvis.enable_voice = self.get_data('enable_voice')
 
     def say(self, text, color="", speak=True):
         """
@@ -143,12 +145,14 @@ class JarvisAPI(object):
         Use text to speech for every text passed to jarvis.say()
         """
         self._jarvis.enable_voice = True
+        self.update_data('enable_voice', True)
 
     def disable_voice(self):
         """
         Stop text to speech output for every text passed to jarvis.say()
         """
         self._jarvis.enable_voice = False
+        self.update_data('enable_voice', False)
 
     def is_voice_enabled(self):
         """

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -1,3 +1,4 @@
+import re
 from utilities.GeneralUtilities import IS_MACOS, IS_WIN
 
 
@@ -70,10 +71,23 @@ class VoiceLinux():
         """
 
         if speech != '':
+            speech = self.remove_ansi_escape_seq(speech)
             self.create()
             self.engine.say(speech)
             self.engine.runAndWait()
             self.destroy()
+
+    def remove_ansi_escape_seq(self, speech):
+        """
+        This method removes ANSI escape sequences from a string. If a colorama
+        color code is accidentally passed to text_to_speech, the ANSI codes will
+        be spoken if they are not removed first.
+
+        :param speech: The text that may contain ANSI escape sequences.
+        :return: The speech with ANSI escape sequences removed. 
+        """
+        speech = re.sub('''(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]''', '', speech)
+        return speech
 
 
 class VoiceWin():

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -19,16 +19,17 @@ def create_voice():
         except OSError:
             return VoiceNotSupported()
 
+
 def remove_ansi_escape_seq(text):
     """
     This method removes ANSI escape sequences (such as a colorama color
     code) from a string so that they aren't spoken.
 
     :param text: The text that may contain ANSI escape sequences.
-    :return: The text with ANSI escape sequences removed. 
+    :return: The text with ANSI escape sequences removed.
     """
     if text:
-        text = re.sub('''(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]''', '', text)
+        text = re.sub(r'''(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]''', '', text)
     return text
 
 

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -1,3 +1,4 @@
+import re
 from utilities.GeneralUtilities import IS_MACOS, IS_WIN
 
 
@@ -18,6 +19,17 @@ def create_voice():
         except OSError:
             return VoiceNotSupported()
 
+def remove_ansi_escape_seq(text):
+    """
+    This method removes ANSI escape sequences (such as a colorama color
+    code) from a string so that they aren't spoken.
+
+    :param text: The text that may contain ANSI escape sequences.
+    :return: The text with ANSI escape sequences removed. 
+    """
+    text = re.sub('''(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]''', '', text)
+    return text
+
 
 # class Voice:
 #     """
@@ -32,6 +44,7 @@ def create_voice():
 
 class VoiceMac():
     def text_to_speech(self, speech):
+        speech = remove_ansi_escape_seq(speech)
         speech = speech.replace("'", "\\'")
         system('say $\'{}\''.format(speech))
 
@@ -70,6 +83,7 @@ class VoiceLinux():
         """
 
         if speech != '':
+            speech = remove_ansi_escape_seq(speech)
             self.create()
             self.engine.say(speech)
             self.engine.runAndWait()
@@ -105,6 +119,7 @@ class VoiceWin():
         :param speech: The text we want Jarvis to generate as audio
         :return: Nothing to return.
         """
+        speech = remove_ansi_escape_seq(speech)
         self.create()
         self.engine.say(speech)
         self.engine.runAndWait()

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -27,7 +27,8 @@ def remove_ansi_escape_seq(text):
     :param text: The text that may contain ANSI escape sequences.
     :return: The text with ANSI escape sequences removed. 
     """
-    text = re.sub('''(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]''', '', text)
+    if text:
+        text = re.sub('''(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]''', '', text)
     return text
 
 

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -1,4 +1,3 @@
-import re
 from utilities.GeneralUtilities import IS_MACOS, IS_WIN
 
 
@@ -71,23 +70,10 @@ class VoiceLinux():
         """
 
         if speech != '':
-            speech = self.remove_ansi_escape_seq(speech)
             self.create()
             self.engine.say(speech)
             self.engine.runAndWait()
             self.destroy()
-
-    def remove_ansi_escape_seq(self, speech):
-        """
-        This method removes ANSI escape sequences from a string. If a colorama
-        color code is accidentally passed to text_to_speech, the ANSI codes will
-        be spoken if they are not removed first.
-
-        :param speech: The text that may contain ANSI escape sequences.
-        :return: The speech with ANSI escape sequences removed. 
-        """
-        speech = re.sub('''(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]''', '', speech)
-        return speech
 
 
 class VoiceWin():


### PR DESCRIPTION
Adds feature mentioned in #651. 

### Changes
- Load `enable_voice` setting from memory when JarvisAPI is initialized.
- Set `enable_voice` setting in memory when it is enabled or disabled.
- Add and call method for removing ANSI escape sequences from all `text_to_speech()` inputs
  - If this isn't included, colorama color codes passed to `text_to_speech()` (ie `Jarvis.first_reaction_text`) will be read aloud as m39, m40, etc