### PR TITLE
Implement #653: Add speech rate control

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -167,7 +167,7 @@ class JarvisAPI(object):
         :param delta: Amount of change to apply to speech rate
         """
         new_rate = self._jarvis.speech.change_rate(delta)
-        self.update_data('speech_rate', new_rate)
+        self.update_data('speech_rate', self._jarvis.speech.rate)
 
     # MEMORY WRAPPER
     def get_data(self, key):

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -166,7 +166,7 @@ class JarvisAPI(object):
         the new speech rate.
         :param delta: Amount of change to apply to speech rate
         """
-        new_rate = self._jarvis.speech.change_rate(delta)
+        self._jarvis.speech.change_rate(delta)
         self.update_data('speech_rate', self._jarvis.speech.rate)
 
     # MEMORY WRAPPER

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -162,6 +162,13 @@ class JarvisAPI(object):
         """
         return self._jarvis.enable_voice
 
+    def change_speech_rate(self, delta):
+        """
+        Alters the rate of the speech engine by a specified amount
+        :param delta: Amount of change to apply to speech rate
+        """
+        self._jarvis.speech.change_rate(delta)
+
     # MEMORY WRAPPER
     def get_data(self, key):
         """

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -32,12 +32,6 @@ class JarvisAPI(object):
     def __init__(self, jarvis):
         self._jarvis = jarvis
         self.spinner_running = False
-        # Remember if voice is currently enabled or not
-        self._jarvis.enable_voice = self.get_data('enable_voice')
-        # Remember speech rate if it was previously set
-        self.speech_rate = self.get_data('speech_rate')
-        if not self.speech_rate:
-            self.speech_rate = 120
 
     def say(self, text, color="", speak=True):
         """
@@ -265,8 +259,7 @@ class CmdInterpreter(Cmd):
             first_reaction_text,
             prompt,
             directories=[],
-            first_reaction=True,
-            enable_voice=False):
+            first_reaction=True):
         """
         This constructor contains a dictionary with Jarvis Actions (what Jarvis can do).
         In alphabetically order.
@@ -275,16 +268,22 @@ class CmdInterpreter(Cmd):
         self.first_reaction = first_reaction
         self.first_reaction_text = first_reaction_text
         self.prompt = prompt
-        self.enable_voice = enable_voice
         # Register do_quit() function to SIGINT signal (Ctrl-C)
         signal.signal(signal.SIGINT, self.interrupt_handler)
 
         self.memory = Memory()
         self.scheduler = schedule.Scheduler()
         self._api = JarvisAPI(self)
+
+        # Remember voice settings
+        self.enable_voice = self._api.get_data('enable_voice')
+        self.speech_rate = self._api.get_data('speech_rate')
+        if not self.speech_rate:
+            self.speech_rate = 120
+
         # what if the platform does not have any engines, travis doesn't have sapi5 acc to me
         try:
-            self.speech = create_voice(rate=self._api.speech_rate)
+            self.speech = create_voice(rate=self.speech_rate)
         except Exception as e:
             print_say("Voice not supported", self, Fore.RED)
             print_say(str(e), self, Fore.RED)

--- a/jarviscli/Jarvis.py
+++ b/jarviscli/Jarvis.py
@@ -46,13 +46,13 @@ class Jarvis(CmdInterpreter, object):
     # This can be used to store user specific data
 
     def __init__(self, first_reaction_text=first_reaction_text,
-                 prompt=prompt, first_reaction=True, enable_voice=False,
+                 prompt=prompt, first_reaction=True,
                  directories=["jarviscli/plugins", "custom"]):
         directories = self._rel_path_fix(directories)
         self.use_rawinput = False
         self.regex_dot = re.compile('\\.(?!\\w)')
         CmdInterpreter.__init__(self, first_reaction_text, prompt,
-                                directories, first_reaction, enable_voice)
+                                directories, first_reaction)
 
     def _rel_path_fix(self, dirs):
         dirs_abs = []

--- a/jarviscli/plugins/voice.py
+++ b/jarviscli/plugins/voice.py
@@ -30,6 +30,8 @@ def say(jarvis, s):
 @require(platform=[LINUX, WINDOWS])
 @plugin('talk faster')
 def talk_faster(jarvis, s):
+    """Make Jarvis' speech engine talk faster.
+    """
     if jarvis.is_voice_enabled():
         jarvis.change_speech_rate(40)
     else:
@@ -40,6 +42,8 @@ def talk_faster(jarvis, s):
 @require(platform=[LINUX, WINDOWS])
 @plugin('talk slower')
 def talk_slower(jarvis, s):
+    """Make Jarvis' speech engine talk slower.
+    """
     if jarvis.is_voice_enabled():
         jarvis.change_speech_rate(-40)
     else:

--- a/jarviscli/plugins/voice.py
+++ b/jarviscli/plugins/voice.py
@@ -1,5 +1,5 @@
 from colorama import Fore
-from plugin import plugin
+from plugin import LINUX, UNIX, MACOS, WINDOWS, plugin, require
 
 
 @plugin('enable sound')
@@ -27,6 +27,7 @@ def say(jarvis, s):
             jarvis.disable_voice()
 
 
+@require(platform=[LINUX, WINDOWS])
 @plugin('talk faster')
 def talk_faster(jarvis, s):
     if jarvis.is_voice_enabled():
@@ -36,6 +37,7 @@ def talk_faster(jarvis, s):
             Fore.BLUE)
 
 
+@require(platform=[LINUX, WINDOWS])
 @plugin('talk slower')
 def talk_slower(jarvis, s):
     if jarvis.is_voice_enabled():

--- a/jarviscli/plugins/voice.py
+++ b/jarviscli/plugins/voice.py
@@ -1,3 +1,4 @@
+from colorama import Fore
 from plugin import plugin
 
 
@@ -25,11 +26,17 @@ def say(jarvis, s):
         if not voice_state:
             jarvis.disable_voice()
 
-# TODO: Add a message if voice is disabled
 @plugin('talk faster')
 def talk_faster(jarvis, s):
-    jarvis.change_speech_rate(25)
+    if jarvis.is_voice_enabled():
+        jarvis.change_speech_rate(40)
+    else:
+        jarvis.say("Type 'enable sound' to allow Jarvis to talk out loud.", Fore.BLUE)
 
 @plugin('talk slower')
 def talk_slower(jarvis, s):
-    jarvis.change_speech_rate(-25)
+    if jarvis.is_voice_enabled():
+        jarvis.change_speech_rate(-40)
+    else:
+        jarvis.say("Type 'enable sound' to allow Jarvis to talk out loud.", Fore.BLUE)
+        

--- a/jarviscli/plugins/voice.py
+++ b/jarviscli/plugins/voice.py
@@ -24,3 +24,12 @@ def say(jarvis, s):
         jarvis.say(s)
         if not voice_state:
             jarvis.disable_voice()
+
+# TODO: Add a message if voice is disabled
+@plugin('talk faster')
+def talk_faster(jarvis, s):
+    jarvis.change_speech_rate(25)
+
+@plugin('talk slower')
+def talk_slower(jarvis, s):
+    jarvis.change_speech_rate(-25)

--- a/jarviscli/plugins/voice.py
+++ b/jarviscli/plugins/voice.py
@@ -26,17 +26,20 @@ def say(jarvis, s):
         if not voice_state:
             jarvis.disable_voice()
 
+
 @plugin('talk faster')
 def talk_faster(jarvis, s):
     if jarvis.is_voice_enabled():
         jarvis.change_speech_rate(40)
     else:
-        jarvis.say("Type 'enable sound' to allow Jarvis to talk out loud.", Fore.BLUE)
+        jarvis.say("Type 'enable sound' to allow Jarvis to talk out loud.",
+            Fore.BLUE)
+
 
 @plugin('talk slower')
 def talk_slower(jarvis, s):
     if jarvis.is_voice_enabled():
         jarvis.change_speech_rate(-40)
     else:
-        jarvis.say("Type 'enable sound' to allow Jarvis to talk out loud.", Fore.BLUE)
-        
+        jarvis.say("Type 'enable sound' to allow Jarvis to talk out loud.",
+            Fore.BLUE)

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -57,7 +57,6 @@ class VoiceLinux():
         This constructor creates a pyttsx3 object.
         """
         self.create()
-        self.engine = None
 
     def create(self):
         """
@@ -83,13 +82,19 @@ class VoiceLinux():
 
         A bug in pyttsx3 causes segfault if speech is '', so used 'if' to avoid that.
         """
-
         if speech != '':
             speech = remove_ansi_escape_seq(speech)
-            self.create()
             self.engine.say(speech)
             self.engine.runAndWait()
-            self.destroy()
+            self.engine.stop()
+
+    def change_rate(self, delta):
+        """
+        This method modifies the rate of the speech engine.
+        :param delta: The amount to modify the rate from the current rate.
+        """
+        current_rate = self.engine.getProperty('rate')
+        self.engine.setProperty('rate', current_rate + delta)
 
 
 class VoiceWin():

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -16,7 +16,7 @@ def create_voice(rate=120):
     if IS_MACOS:
         return VoiceMac()
     elif IS_WIN:
-        return VoiceWin()
+        return VoiceWin(rate)
     else:
         try:
             return VoiceLinux(rate)
@@ -106,19 +106,19 @@ class VoiceLinux():
 
 
 class VoiceWin():
-    def __init__(self):
+    def __init__(self, rate):
         """
         This constructor creates a pyttsx3 object.
         """
-        self.create()
+        self.create(rate)
 
-    def create(self):
+    def create(self, rate):
         """
         This method creates a pyttsx3 object.
         :return: Nothing to return.
         """
         self.engine = pyttsx3.init("sapi5")
-        self.engine.setProperty('rate', 120)
+        self.engine.setProperty('rate', rate)
 
     def destroy(self):
         """
@@ -135,10 +135,20 @@ class VoiceWin():
         :return: Nothing to return.
         """
         speech = remove_ansi_escape_seq(speech)
-        self.create()
         self.engine.say(speech)
         self.engine.runAndWait()
-        self.destroy()
+        self.engine.stop()
+
+    def change_rate(self, delta):
+        """
+        This method modifies the rate of the speech engine.
+        :param delta: The amount to modify the rate from the current rate.
+        :return: The updated speech rate.
+        """
+        current_rate = self.engine.getProperty('rate')
+        new_rate = current_rate + delta
+        self.engine.setProperty('rate', new_rate)
+        return new_rate
 
 
 class VoiceNotSupported():

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -60,6 +60,8 @@ class VoiceLinux():
         This constructor creates a pyttsx3 object.
         """
         self.rate = rate
+        self.min_rate = 50
+        self.max_rate = 500
         self.create()
 
     def create(self):
@@ -99,12 +101,17 @@ class VoiceLinux():
     def change_rate(self, delta):
         """
         This method changes the speech rate which is used to set the speech
-        engine rate.
+        engine rate. Restrict the rate to a usable range.
         :param delta: The amount to modify the rate from the current rate.
 
         Note: The actual engine rate is set by create().
         """
-        self.rate = self.rate + delta
+        if self.rate + delta > self.max_rate:
+            self.rate = self.max_rate
+        elif self.rate + delta < self.min_rate:
+            self.rate = self.min_rate
+        else:
+            self.rate = self.rate + delta
 
 
 class VoiceWin():
@@ -113,6 +120,8 @@ class VoiceWin():
         This constructor creates a pyttsx3 object.
         """
         self.rate = rate
+        self.min_rate = 50
+        self.max_rate = 500
         self.create()
 
     def create(self):
@@ -149,12 +158,17 @@ class VoiceWin():
     def change_rate(self, delta):
         """
         This method changes the speech rate which is used to set the speech
-        engine rate.
+        engine rate. Restrict the rate to a usable range.
         :param delta: The amount to modify the rate from the current rate.
 
         Note: The actual engine rate is set by create().
         """
-        self.rate = self.rate + delta
+        if self.rate + delta > self.max_rate:
+            self.rate = self.max_rate
+        elif self.rate + delta < self.min_rate:
+            self.rate = self.min_rate
+        else:
+            self.rate = self.rate + delta
 
 
 class VoiceNotSupported():

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -11,7 +11,7 @@ else:
 # TODO: Add rate for all platforms
 def create_voice(rate=120):
     """
-    :param rate: Speech rate for the engine
+    :param rate: Speech rate for the engine (if supported by the OS)
     """
     if IS_MACOS:
         return VoiceMac()
@@ -60,16 +60,16 @@ class VoiceLinux():
         """
         This constructor creates a pyttsx3 object.
         """
-        self.create(rate)
+        self.rate = rate
+        self.create()
 
-    def create(self, rate):
+    def create(self):
         """
         This method creates a pyttsx3 object.
-        :param rate: Speech rate for the engine.
         :return: Nothing to return.
         """
         self.engine = pyttsx3.init()
-        self.engine.setProperty('rate', rate)
+        self.engine.setProperty('rate', self.rate)
 
     def destroy(self):
         """
@@ -97,12 +97,10 @@ class VoiceLinux():
         """
         This method modifies the rate of the speech engine.
         :param delta: The amount to modify the rate from the current rate.
-        :return: The updated speech rate.
         """
         current_rate = self.engine.getProperty('rate')
-        new_rate = current_rate + delta
-        self.engine.setProperty('rate', new_rate)
-        return new_rate
+        self.rate = current_rate + delta
+        self.engine.setProperty('rate', self.rate)
 
 
 class VoiceWin():
@@ -110,15 +108,16 @@ class VoiceWin():
         """
         This constructor creates a pyttsx3 object.
         """
-        self.create(rate)
+        self.rate = rate
+        self.create()
 
-    def create(self, rate):
+    def create(self):
         """
         This method creates a pyttsx3 object.
         :return: Nothing to return.
         """
         self.engine = pyttsx3.init("sapi5")
-        self.engine.setProperty('rate', rate)
+        self.engine.setProperty('rate', self.rate)
 
     def destroy(self):
         """
@@ -143,12 +142,10 @@ class VoiceWin():
         """
         This method modifies the rate of the speech engine.
         :param delta: The amount to modify the rate from the current rate.
-        :return: The updated speech rate.
         """
         current_rate = self.engine.getProperty('rate')
-        new_rate = current_rate + delta
-        self.engine.setProperty('rate', new_rate)
-        return new_rate
+        self.rate = current_rate + delta
+        self.engine.setProperty('rate', self.rate)
 
 
 class VoiceNotSupported():

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -65,7 +65,7 @@ class VoiceLinux():
     def create(self, rate):
         """
         This method creates a pyttsx3 object.
-        :param rate: Speech rate for the engine. 
+        :param rate: Speech rate for the engine.
         :return: Nothing to return.
         """
         self.engine = pyttsx3.init()

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -8,7 +8,6 @@ else:
     import pyttsx3
 
 
-# TODO: Add rate for all platforms
 def create_voice(rate=120):
     """
     :param rate: Speech rate for the engine (if supported by the OS)
@@ -86,21 +85,26 @@ class VoiceLinux():
         :return: Nothing to return.
 
         A bug in pyttsx3 causes segfault if speech is '', so used 'if' to avoid that.
+
+        Instability in the pyttsx3 engine can cause problems if the engine is
+        not created and destroyed every time it is used.
         """
         if speech != '':
             speech = remove_ansi_escape_seq(speech)
+            self.create()
             self.engine.say(speech)
             self.engine.runAndWait()
-            self.engine.stop()
+            self.destroy()
 
     def change_rate(self, delta):
         """
-        This method modifies the rate of the speech engine.
+        This method changes the speech rate which is used to set the speech
+        engine rate.
         :param delta: The amount to modify the rate from the current rate.
+
+        Note: The actual engine rate is set by create().
         """
-        current_rate = self.engine.getProperty('rate')
-        self.rate = current_rate + delta
-        self.engine.setProperty('rate', self.rate)
+        self.rate = self.rate + delta
 
 
 class VoiceWin():
@@ -132,20 +136,25 @@ class VoiceWin():
         This method converts a text to speech.
         :param speech: The text we want Jarvis to generate as audio
         :return: Nothing to return.
+
+        Instability in the pyttsx3 engine can cause problems if the engine is
+        not created and destroyed every time it is used.
         """
         speech = remove_ansi_escape_seq(speech)
+        self.create()
         self.engine.say(speech)
         self.engine.runAndWait()
-        self.engine.stop()
+        self.destroy()
 
     def change_rate(self, delta):
         """
-        This method modifies the rate of the speech engine.
+        This method changes the speech rate which is used to set the speech
+        engine rate.
         :param delta: The amount to modify the rate from the current rate.
+
+        Note: The actual engine rate is set by create().
         """
-        current_rate = self.engine.getProperty('rate')
-        self.rate = current_rate + delta
-        self.engine.setProperty('rate', self.rate)
+        self.rate = self.rate + delta
 
 
 class VoiceNotSupported():

--- a/jarviscli/utilities/voice.py
+++ b/jarviscli/utilities/voice.py
@@ -8,14 +8,18 @@ else:
     import pyttsx3
 
 
-def create_voice():
+# TODO: Add rate for all platforms
+def create_voice(rate=120):
+    """
+    :param rate: Speech rate for the engine
+    """
     if IS_MACOS:
         return VoiceMac()
     elif IS_WIN:
         return VoiceWin()
     else:
         try:
-            return VoiceLinux()
+            return VoiceLinux(rate)
         except OSError:
             return VoiceNotSupported()
 
@@ -52,19 +56,20 @@ class VoiceMac():
 
 
 class VoiceLinux():
-    def __init__(self):
+    def __init__(self, rate):
         """
         This constructor creates a pyttsx3 object.
         """
-        self.create()
+        self.create(rate)
 
-    def create(self):
+    def create(self, rate):
         """
         This method creates a pyttsx3 object.
+        :param rate: Speech rate for the engine. 
         :return: Nothing to return.
         """
         self.engine = pyttsx3.init()
-        self.engine.setProperty('rate', 120)
+        self.engine.setProperty('rate', rate)
 
     def destroy(self):
         """
@@ -92,9 +97,12 @@ class VoiceLinux():
         """
         This method modifies the rate of the speech engine.
         :param delta: The amount to modify the rate from the current rate.
+        :return: The updated speech rate.
         """
         current_rate = self.engine.getProperty('rate')
-        self.engine.setProperty('rate', current_rate + delta)
+        new_rate = current_rate + delta
+        self.engine.setProperty('rate', new_rate)
+        return new_rate
 
 
 class VoiceWin():


### PR DESCRIPTION
This PR adds speed control plugins mentioned in #653 that allow the user to change Jarvis' speech rate with 'talk faster' and 'talk slower' if voice is enabled. Additionally, speech rate is saved in Jarvis' memory so that it can be recalled between sessions. In order to enable these plugins, some changes were made to the JarvisAPI, to Jarvis and CmdInterpreter, and to the voice utility.  

### Changes
- Add `talk faster` and `talk slower` plugins to `plugins/voice.py`
- Add a `change_speech_rate` method to the JarvisAPI to interface between the plugins and the speech engine
- Recall `rate` when CmdInterpreter is initialized
- Move `enable_voice` recall out of the API and into CmdInterpreter, since it seems more logical to do all settings recall there
- Remove `enable_voice` parameters from Jarvis because it will now be recalled from memory or default to off if not previously set
- Add a `rate` parameter to `create_voice` which is then passed to Voice classes and stored
- Add a setter for `rate` for each Voice class that modifies the value
- Modify the `create` method for each voice class to set the speech rate when the engine is created
- Save `min_rate` and `max_rate` attributes and restrict `rate` inside that range