### PR TITLE
Fix scenario when cd fails before other commands

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -12,5 +12,4 @@ echo "checking for unit test"
 python3 -m unittest discover
 echo "unit tests checked"
 echo ""
-cd ..
 )

--- a/test.sh
+++ b/test.sh
@@ -6,9 +6,11 @@ echo "checking for linting errors"
 flake8 --select E,W --max-line-length=140 --ignore E722,W503,W504,E128 jarviscli/ installer
 echo "lint errors checked"
 echo ""
-cd jarviscli/
+(
+cd jarviscli || exit
 echo "checking for unit test"
 python3 -m unittest discover
 echo "unit tests checked"
 echo ""
 cd ..
+)


### PR DESCRIPTION
Change 'python -m unittest discover' call to run in a Sub-shell.

if sequences such as 'cd dir; do something; cd ..', happen to fail (e.g. if dir was deleted or user lacks permission to access it), 'do something' will be executed in the wrong directory producing unwanted results.

These changes prevent this from happening by using a subshell.