### PR TITLE
Updated keywords list

### DIFF
--- a/jarviscli/packages/forecast.py
+++ b/jarviscli/packages/forecast.py
@@ -8,7 +8,7 @@ from utilities.dateTime import WeekDay
 
 
 def main(jarvis, s):
-    cmd_key_words = ['check', 'weather', 'forecast', 'in', 'for']
+    cmd_key_words = ['check', 'weather', 'forecast', 'in', 'for', 'a', 'week']
     cmd_words = s.strip().split()
     # location will be defined by the words given that are not the key words
     location = ' '.join(filter(lambda word: word.lower()


### PR DESCRIPTION
New user might type "check forecast in {location} for a week". So adding 'a' and 'week' to keywords list will make forecast call more user-friendly.