### PR TITLE
Add create_plugin.py plugin 

### DIFF
--- a/jarviscli/plugins/create_plugin.py
+++ b/jarviscli/plugins/create_plugin.py
@@ -9,9 +9,8 @@ to ecourage people to experiment with jarvis's plugins.
 """The os.path method is used to track the path in which this plugin is stored
 and locate the Jarvis/custom folder through relative pathing.
 """
-path = os.path.abspath(__file__)
-plugins_path = os.path.dirname(path)
-custom_plugins_path = os.path.join(plugins_path, '..', '..', 'custom/')
+PLUGINS_PATH = os.path.dirname(os.path.abspath(__file__))
+CUSTOM_PLUGINS_PATH = os.path.join(PLUGINS_PATH, '..', '..', 'custom/')
 
 
 @require(platform=MACOS)
@@ -33,8 +32,8 @@ def create_plugin_MAC(jarvis, s):
     """Checks if file already exists in either the plugins main folder
     or in the custom plugins folder and also asks the user if he wants to exit
     """
-    while(os.path.isfile(custom_plugins_path + filename + ".py") or
-          os.path.isfile(plugins_path + "/" + filename + ".py") and not exit):
+    while(os.path.isfile(CUSTOM_PLUGINS_PATH + filename + ".py") or
+          os.path.isfile(PLUGINS_PATH + "/" + filename + ".py") and not exit):
         jarvis.say("A plugin with the name '" + filename + "' already exists", Fore.RED)
         jarvis.say("Please choose another name or type 'exit' for obvious results:", Fore.CYAN)
 
@@ -46,13 +45,13 @@ def create_plugin_MAC(jarvis, s):
         """The templated is generated through the create_template funcion
         and is exceuted through the os.system method.
         """
-        string = create_template(custom_plugins_path, filename)
+        string = create_template(CUSTOM_PLUGINS_PATH, filename)
         os.system(string)
 
-        if os.path.isfile(custom_plugins_path + filename + ".py"):
+        if os.path.isfile(CUSTOM_PLUGINS_PATH + filename + ".py"):
             jarvis.say(filename + ".py created successfully inside Jarvis/custom",
                        Fore.CYAN)
-            string = "open " + custom_plugins_path + filename + ".py"
+            string = "open " + CUSTOM_PLUGINS_PATH + filename + ".py"
             os.system(string)
         else:
             jarvis.say("Something went wrong in the creation of the plugin :(",
@@ -79,8 +78,8 @@ def create_plugin_LINUX(jarvis, s):
     """Checks if file already exists in either the plugins main folder
     or in the custom plugins folder and also asks the user if he wants to exit
     """
-    while(os.path.isfile(custom_plugins_path + filename + ".py") or
-          os.path.isfile(plugins_path + "/" + filename + ".py") and not exit):
+    while(os.path.isfile(CUSTOM_PLUGINS_PATH + filename + ".py") or
+          os.path.isfile(PLUGINS_PATH + "/" + filename + ".py") and not exit):
         jarvis.say("A plugin with the name '" + filename + "' already exists", Fore.RED)
         jarvis.say("Please choose another name or type 'exit' for obvious results:", Fore.CYAN)
 
@@ -92,13 +91,13 @@ def create_plugin_LINUX(jarvis, s):
         """The plugin is created through the Terminal command "cat"
         and excecuted with the os.System method.
         """
-        string = create_template(custom_plugins_path, filename)
+        string = create_template(CUSTOM_PLUGINS_PATH, filename)
         os.system(string)
 
-        if os.path.isfile(custom_plugins_path + filename + ".py"):
+        if os.path.isfile(CUSTOM_PLUGINS_PATH + filename + ".py"):
             jarvis.say(filename + ".py created successfully inside Jarvis/custom",
                        Fore.CYAN)
-            string = "xdg-open " + custom_plugins_path + filename + ".py"
+            string = "xdg-open " + CUSTOM_PLUGINS_PATH + filename + ".py"
             os.system(string)
         else:
             jarvis.say("Something went wrong in the creation of the plugin :(",
@@ -106,7 +105,8 @@ def create_plugin_LINUX(jarvis, s):
 
 
 def format_filename(name):
-	"""Take a string and return a valid filename constructed from the string.
+
+    """Take a string and return a valid filename constructed from the string.
 Uses a whitelist approach: any characters not present in valid_chars are
 removed. Also spaces are replaced with underscores.
 
@@ -123,12 +123,12 @@ an invalid filename.
     return filename
 
 
-def create_template(custom_plugins_path, filename):
-	"""This method is used to format the template of the plugin
+def create_template(path, filename):
+    """This method is used to format the template of the plugin
 that is being created given the filename and the path
 in which it will be stored.
 """
-	template = """cd """ + custom_plugins_path + """
+    template = """cd """ + path + """
             cat >> """ + filename + """.py << EOL
 # All plugins should inherite from this library
 from plugin import plugin
@@ -151,4 +151,4 @@ def my_plugin(jarvis, s):
 # https://github.com/sukeesh/Jarvis/blob/master/doc/PLUGINS.md
 EOL"""
 
-	return template
+    return template

--- a/jarviscli/plugins/create_plugin.py
+++ b/jarviscli/plugins/create_plugin.py
@@ -1,0 +1,175 @@
+import os
+from colorama import Fore
+from plugin import plugin, require, MACOS, LINUX
+"""This plugin is developed for developers as its use is to create a template
+based on the guidlines of the creators of the project
+to ecourage people to experiment with jarvis's plugins.
+"""
+
+
+@require(platform=MACOS)
+@plugin("create plugin")
+def create_plugin_MAC(jarvis, s):
+    """The os.path method is used to track the path in which this plugin is stored
+    and locate the Jarvis/custom folder through relative pathing.
+    """
+    path = os.path.abspath(__file__)
+    plugins_path = os.path.dirname(path)
+    custom_plugins_path = os.path.join(plugins_path, '..', '..', 'custom/')
+
+    # Jarvis asks for the name of the plugin to create if not provided.
+
+    if s == "":
+        jarvis.say("Please insert the name of your plugin: ", Fore.RED)
+        name = jarvis.input()
+    else:
+        name = s
+    """The name fillters through the format_file name
+    which converts it to a valid filename.
+    """
+    filename = format_filename(name)
+    # Flag to terminate process
+    exit = False
+    """Checks if file already exists in either the plugins main folder
+    or in the custom plugins folder and also asks the user if he wants to exit
+    """
+    while(os.path.isfile(custom_plugins_path + filename + ".py") or
+          os.path.isfile(plugins_path + "/" + filename + ".py") and not exit):
+        jarvis.say("A plugin with the name '" + filename + "' already exists", Fore.RED)
+        jarvis.say("Please choose another name or type 'exit' for obvious results:", Fore.CYAN)
+
+        new_name = jarvis.input()
+        if new_name == 'exit':
+            exit = True
+        filename = format_filename(new_name)
+    if(not exit):
+        """The plugin is created through the Terminal command "cat"
+        and excecuted with the os.System method and it is opened automaticaly
+        with the open command if created with the users deafult editor.
+        """
+        string = """cd """ + custom_plugins_path + """
+            cat >> """ + filename + """.py << EOL
+# All plugins should inherite from this library
+from plugin import plugin
+
+# This is the standard form of a plugin for jarvis
+
+# Anytime you make a change REMEMBER TO RESTART Jarvis
+
+# You can run it through jarvis by the name
+# in the @plugin tag.
+
+
+@plugin("my plugin")
+def my_plugin(jarvis, s):
+
+    # Prints 'This is my new plugin!'
+    jarvis.say("This is my new plugin!")
+
+# For more info about plugin development visit:
+# https://github.com/sukeesh/Jarvis/blob/master/doc/PLUGINS.md
+EOL"""
+        os.system(string)
+
+        if os.path.isfile(custom_plugins_path + filename + ".py"):
+            jarvis.say(filename + ".py created successfully inside Jarvis/custom",
+                       Fore.CYAN)
+            string = "open " + custom_plugins_path + filename + ".py"
+            os.system(string)
+        else:
+            jarvis.say("Something went wrong in the creation of the plugin :(",
+                       Fore.RED)
+
+"""The only difference for LINUX os is that the file
+is not opened after creation because the LINUX open command
+uses terminal based editors which are not practical in this case.
+"""
+
+
+@require(platform=LINUX)
+@plugin("create plugin")
+def create_plugin_LINUX(jarvis, s):
+    """The os.path method is used to track the path in which this plugin is stored
+    and locate the Jarvis/custom folder through relative pathing.
+    """
+    path = os.path.abspath(__file__)
+    plugins_path = os.path.dirname(path)
+    custom_plugins_path = os.path.join(plugins_path, '..', '..', 'custom/')
+
+    # Jarvis asks for the name of the plugin to create if not provided.
+
+    if s == "":
+        jarvis.say("Please insert the name of your plugin: ", Fore.RED)
+        name = jarvis.input()
+    else:
+        name = s
+    """The name fillters through the format_file name
+    which converts it to a valid filename.
+    """
+    filename = format_filename(name)
+    # Flag to terminate process
+    exit = False
+    """Checks if file already exists in either the plugins main folder
+    or in the custom plugins folder and also asks the user if he wants to exit
+    """
+    while(os.path.isfile(custom_plugins_path + filename + ".py") or
+          os.path.isfile(plugins_path + "/" + filename + ".py") and not exit):
+        jarvis.say("A plugin with the name '" + filename + "' already exists", Fore.RED)
+        jarvis.say("Please choose another name or type 'exit' for obvious results:", Fore.CYAN)
+
+        new_name = jarvis.input()
+        if new_name == 'exit':
+            exit = True
+        filename = format_filename(new_name)
+    if(not exit):
+        """The plugin is created through the Terminal command "cat"
+        and excecuted with the os.System method.
+        """
+        string = """cd """ + custom_plugins_path + """
+            cat >> """ + filename + """.py << EOL
+# All plugins should inherite from this library
+from plugin import plugin
+
+# This is the standard form of a plugin for jarvis
+
+# Anytime you make a change REMEMBER TO RESTART Jarvis
+
+# You can run it through jarvis by the name
+# in the @plugin tag.
+
+
+@plugin("my plugin")
+def my_plugin(jarvis, s):
+
+    # Prints 'This is my new plugin!'
+    jarvis.say("This is my new plugin!")
+
+# For more info about plugin development visit:
+# https://github.com/sukeesh/Jarvis/blob/master/doc/PLUGINS.md
+EOL"""
+        os.system(string)
+        if os.path.isfile(custom_plugins_path + filename + ".py"):
+            jarvis.say(filename + ".py created successfully inside Jarvis/custom",
+                       Fore.CYAN)
+        else:
+            jarvis.say("Something went wrong in the creation of the plugin :(",
+                       Fore.RED)
+
+
+def format_filename(name):
+    """Take a string and return a valid filename constructed from the string.
+Uses a whitelist approach: any characters not present in valid_chars are
+removed. Also spaces are replaced with underscores.
+
+Note: this method may produce invalid filenames such as ``, `.` or `..`
+When I use this method I prepend a date string like '2009_01_15_19_46_32_'
+and append a file extension like '.txt', so I avoid the potential of using
+an invalid filename.
+
+"""
+    import string
+
+    valid_chars = "-_.() %s%s" % (string.ascii_letters, string.digits)
+    filename = ''.join(c for c in name if c in valid_chars)
+    filename = filename.replace(' ', '_')  # I don't like spaces in filenames.
+    return filename

--- a/jarviscli/plugins/create_plugin.py
+++ b/jarviscli/plugins/create_plugin.py
@@ -151,6 +151,8 @@ EOL"""
         if os.path.isfile(custom_plugins_path + filename + ".py"):
             jarvis.say(filename + ".py created successfully inside Jarvis/custom",
                        Fore.CYAN)
+            string = "xdg-open " + custom_plugins_path + filename + ".py"
+            os.system(string)
         else:
             jarvis.say("Something went wrong in the creation of the plugin :(",
                        Fore.RED)

--- a/jarviscli/plugins/create_plugin.py
+++ b/jarviscli/plugins/create_plugin.py
@@ -43,32 +43,10 @@ def create_plugin_MAC(jarvis, s):
             exit = True
         filename = format_filename(new_name)
     if(not exit):
-        """The plugin is created through the Terminal command "cat"
-        and excecuted with the os.System method and it is opened automaticaly
-        with the open command if created with the users deafult editor.
+        """The templated is generated through the create_template funcion
+        and is exceuted through the os.system method.
         """
-        string = """cd """ + custom_plugins_path + """
-            cat >> """ + filename + """.py << EOL
-# All plugins should inherite from this library
-from plugin import plugin
-
-# This is the standard form of a plugin for jarvis
-
-# Anytime you make a change REMEMBER TO RESTART Jarvis
-
-# You can run it through jarvis by the name
-# in the @plugin tag.
-
-
-@plugin("my plugin")
-def my_plugin(jarvis, s):
-
-    # Prints 'This is my new plugin!'
-    jarvis.say("This is my new plugin!")
-
-# For more info about plugin development visit:
-# https://github.com/sukeesh/Jarvis/blob/master/doc/PLUGINS.md
-EOL"""
+        string = create_template(custom_plugins_path, filename)
         os.system(string)
 
         if os.path.isfile(custom_plugins_path + filename + ".py"):
@@ -80,10 +58,6 @@ EOL"""
             jarvis.say("Something went wrong in the creation of the plugin :(",
                        Fore.RED)
 
-"""The only difference for LINUX os is that the file
-is not opened after creation because the LINUX open command
-uses terminal based editors which are not practical in this case.
-"""
 
 
 @require(platform=LINUX)
@@ -175,3 +149,34 @@ an invalid filename.
     filename = ''.join(c for c in name if c in valid_chars)
     filename = filename.replace(' ', '_')  # I don't like spaces in filenames.
     return filename
+
+"""This method is used to format the template of the plugin
+that is being created given the filename and the path
+in which it will be stored.
+"""
+def create_template(custom_plugins_path, filename):
+
+	template = """cd """ + custom_plugins_path + """
+            cat >> """ + filename + """.py << EOL
+# All plugins should inherite from this library
+from plugin import plugin
+
+# This is the standard form of a plugin for jarvis
+
+# Anytime you make a change REMEMBER TO RESTART Jarvis
+
+# You can run it through jarvis by the name
+# in the @plugin tag.
+
+
+@plugin("my plugin")
+def my_plugin(jarvis, s):
+
+    # Prints 'This is my new plugin!'
+    jarvis.say("This is my new plugin!")
+
+# For more info about plugin development visit:
+# https://github.com/sukeesh/Jarvis/blob/master/doc/PLUGINS.md
+EOL"""
+
+	return template

--- a/jarviscli/plugins/create_plugin.py
+++ b/jarviscli/plugins/create_plugin.py
@@ -13,10 +13,11 @@ path = os.path.abspath(__file__)
 plugins_path = os.path.dirname(path)
 custom_plugins_path = os.path.join(plugins_path, '..', '..', 'custom/')
 
+
 @require(platform=MACOS)
 @plugin("create plugin")
 def create_plugin_MAC(jarvis, s):
-    
+
     # Jarvis asks for the name of the plugin to create if not provided.
     if s == "":
         jarvis.say("Please insert the name of your plugin: ", Fore.RED)
@@ -58,7 +59,7 @@ def create_plugin_MAC(jarvis, s):
                        Fore.RED)
 
 
-
+# The difference in LINUX is the command used to open the created file
 @require(platform=LINUX)
 @plugin("create plugin")
 def create_plugin_LINUX(jarvis, s):
@@ -105,7 +106,7 @@ def create_plugin_LINUX(jarvis, s):
 
 
 def format_filename(name):
-    """Take a string and return a valid filename constructed from the string.
+	"""Take a string and return a valid filename constructed from the string.
 Uses a whitelist approach: any characters not present in valid_chars are
 removed. Also spaces are replaced with underscores.
 
@@ -113,7 +114,6 @@ Note: this method may produce invalid filenames such as ``, `.` or `..`
 When I use this method I prepend a date string like '2009_01_15_19_46_32_'
 and append a file extension like '.txt', so I avoid the potential of using
 an invalid filename.
-
 """
     import string
 
@@ -122,12 +122,12 @@ an invalid filename.
     filename = filename.replace(' ', '_')  # I don't like spaces in filenames.
     return filename
 
-"""This method is used to format the template of the plugin
+
+def create_template(custom_plugins_path, filename):
+	"""This method is used to format the template of the plugin
 that is being created given the filename and the path
 in which it will be stored.
 """
-def create_template(custom_plugins_path, filename):
-
 	template = """cd """ + custom_plugins_path + """
             cat >> """ + filename + """.py << EOL
 # All plugins should inherite from this library

--- a/jarviscli/plugins/create_plugin.py
+++ b/jarviscli/plugins/create_plugin.py
@@ -6,19 +6,18 @@ based on the guidlines of the creators of the project
 to ecourage people to experiment with jarvis's plugins.
 """
 
+"""The os.path method is used to track the path in which this plugin is stored
+and locate the Jarvis/custom folder through relative pathing.
+"""
+path = os.path.abspath(__file__)
+plugins_path = os.path.dirname(path)
+custom_plugins_path = os.path.join(plugins_path, '..', '..', 'custom/')
 
 @require(platform=MACOS)
 @plugin("create plugin")
 def create_plugin_MAC(jarvis, s):
-    """The os.path method is used to track the path in which this plugin is stored
-    and locate the Jarvis/custom folder through relative pathing.
-    """
-    path = os.path.abspath(__file__)
-    plugins_path = os.path.dirname(path)
-    custom_plugins_path = os.path.join(plugins_path, '..', '..', 'custom/')
-
+    
     # Jarvis asks for the name of the plugin to create if not provided.
-
     if s == "":
         jarvis.say("Please insert the name of your plugin: ", Fore.RED)
         name = jarvis.input()
@@ -63,15 +62,8 @@ def create_plugin_MAC(jarvis, s):
 @require(platform=LINUX)
 @plugin("create plugin")
 def create_plugin_LINUX(jarvis, s):
-    """The os.path method is used to track the path in which this plugin is stored
-    and locate the Jarvis/custom folder through relative pathing.
-    """
-    path = os.path.abspath(__file__)
-    plugins_path = os.path.dirname(path)
-    custom_plugins_path = os.path.join(plugins_path, '..', '..', 'custom/')
 
     # Jarvis asks for the name of the plugin to create if not provided.
-
     if s == "":
         jarvis.say("Please insert the name of your plugin: ", Fore.RED)
         name = jarvis.input()
@@ -99,29 +91,9 @@ def create_plugin_LINUX(jarvis, s):
         """The plugin is created through the Terminal command "cat"
         and excecuted with the os.System method.
         """
-        string = """cd """ + custom_plugins_path + """
-            cat >> """ + filename + """.py << EOL
-# All plugins should inherite from this library
-from plugin import plugin
-
-# This is the standard form of a plugin for jarvis
-
-# Anytime you make a change REMEMBER TO RESTART Jarvis
-
-# You can run it through jarvis by the name
-# in the @plugin tag.
-
-
-@plugin("my plugin")
-def my_plugin(jarvis, s):
-
-    # Prints 'This is my new plugin!'
-    jarvis.say("This is my new plugin!")
-
-# For more info about plugin development visit:
-# https://github.com/sukeesh/Jarvis/blob/master/doc/PLUGINS.md
-EOL"""
+        string = create_template(custom_plugins_path, filename)
         os.system(string)
+
         if os.path.isfile(custom_plugins_path + filename + ".py"):
             jarvis.say(filename + ".py created successfully inside Jarvis/custom",
                        Fore.CYAN)


### PR DESCRIPTION
This plugin is designed to make it easier for a developer to start programming and experimenting with Jarvis plugins. It is functional for MAC and LINUX operating systems.
The format of the template which is created is strictly based on the instructions given in the url attached in README.md.

PS: if you decide to merge, might i suggest to mention the plugin in the README file under plugins compartment.
#674 
