### PR TITLE
Fix bug of _input_queue attribute acting like a stack

### DIFF
--- a/jarviscli/tests/__init__.py
+++ b/jarviscli/tests/__init__.py
@@ -1,6 +1,7 @@
 import unittest
 from functools import partial
 from CmdInterpreter import JarvisAPI
+from collections import deque
 
 
 class MockJarvisAPI(JarvisAPI):
@@ -28,7 +29,7 @@ class MockJarvisAPI(JarvisAPI):
             build()
 
         self.data = {}
-        self._input_queue = []
+        self._input_queue = deque()
         self.is_voice_enabled = False
 
     def say(self, text, color=""):
@@ -43,7 +44,7 @@ class MockJarvisAPI(JarvisAPI):
     def input(self, prompt='', color=''):
         if len(self._input_queue) == 0:
             raise BaseException("MockJarvisAPI: No predefined answer in queue - add answer with 'self.queue_input(\"TEXT\")'")
-        return self._input_queue.pop()
+        return self._input_queue.popleft()
 
     def input_number(self, prompt='', color='', rtype=float, rmin=None, rmax=None):
         return JarvisAPI.input_number(self, prompt, color, rtype, rmin, rmax)


### PR DESCRIPTION
Fix bug of _input_queue attribute in function queue_input at __init__.py acting like a stack
Utilizes  the deque module from collections library to change the
behaviour from LIFO to FIFO as it should #696