### PR TITLE
Changed help function to output aliases in parentheses (issue #617)

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -419,7 +419,34 @@ class CmdInterpreter(Cmd):
                         disabled,
                         " OR ".join(reason)),
                     self)
+    def do_help(self, arg):
+        if arg:
+            Cmd.do_help(self, arg)
+        else:
+            print_say("", self)
+            print_say("These are valid commands for Jarvis", self)
+            print_say("Format: command ([aliases for command]", self, Fore.BLUE)
+            pluginDict = self._plugin_manager.get_plugins()
+            uniquePlugins = {}
+            for key in pluginDict.keys():
+                plugin = pluginDict[key]
+                if(plugin not in uniquePlugins.keys()):
+                    uniquePlugins[plugin.get_name()] = plugin
+            helpOutput = []
+            for name in sorted(uniquePlugins.keys()):
+                if (name == "help" ):
+                    continue
+                try:
+                    aliasString = ", ".join(uniquePlugins[name].alias())
+                    if (aliasString != ""):
+                        pluginOutput = name + " (" + aliasString + ")"
+                        helpOutput.append(pluginOutput)
+                    else:
+                        helpOutput.append(name)
+                except AttributeError:
+                    helpOutput.append(name)
 
+            Cmd.columnize(self, helpOutput)
     def help_status(self):
         print_say("Prints info about enabled or disabled plugins", self)
         print_say("Use \"status short\" to omit detailed information.", self)

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -442,12 +442,12 @@ class CmdInterpreter(Cmd):
                 try:
                     aliasString = ", ".join(uniquePlugins[name].alias())
                     if (aliasString != ""):
-                        pluginOutput = name + " (" + aliasString + ")"
+                        pluginOutput = "* " + name + " (" + aliasString + ")"
                         helpOutput.append(pluginOutput)
                     else:
-                        helpOutput.append(name)
+                        helpOutput.append("* " + name)
                 except AttributeError:
-                    helpOutput.append(name)
+                    helpOutput.append("* " + name)
 
             Cmd.columnize(self, helpOutput)
 

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -419,13 +419,16 @@ class CmdInterpreter(Cmd):
                         disabled,
                         " OR ".join(reason)),
                     self)
+
     def do_help(self, arg):
         if arg:
             Cmd.do_help(self, arg)
         else:
             print_say("", self)
-            print_say("These are valid commands for Jarvis", self)
-            print_say("Format: command ([aliases for command]", self, Fore.BLUE)
+            headerString = "These are valid commands for Jarvis"
+            formatString = "Format : command ([aliases for command]"
+            print_say(headerString, self)
+            print_say(formatString, self, Fore.BLUE)
             pluginDict = self._plugin_manager.get_plugins()
             uniquePlugins = {}
             for key in pluginDict.keys():
@@ -434,7 +437,7 @@ class CmdInterpreter(Cmd):
                     uniquePlugins[plugin.get_name()] = plugin
             helpOutput = []
             for name in sorted(uniquePlugins.keys()):
-                if (name == "help" ):
+                if (name == "help"):
                     continue
                 try:
                     aliasString = ", ".join(uniquePlugins[name].alias())
@@ -447,6 +450,7 @@ class CmdInterpreter(Cmd):
                     helpOutput.append(name)
 
             Cmd.columnize(self, helpOutput)
+
     def help_status(self):
         print_say("Prints info about enabled or disabled plugins", self)
         print_say("Use \"status short\" to omit detailed information.", self)

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -426,7 +426,7 @@ class CmdInterpreter(Cmd):
         else:
             print_say("", self)
             headerString = "These are valid commands for Jarvis"
-            formatString = "Format : command ([aliases for command]"
+            formatString = "Format: command ([aliases for command]"
             print_say(headerString, self)
             print_say(formatString, self, Fore.BLUE)
             pluginDict = self._plugin_manager.get_plugins()

--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -426,7 +426,7 @@ class CmdInterpreter(Cmd):
         else:
             print_say("", self)
             headerString = "These are valid commands for Jarvis"
-            formatString = "Format: command ([aliases for command]"
+            formatString = "Format: command ([aliases for command])"
             print_say(headerString, self)
             print_say(formatString, self, Fore.BLUE)
             pluginDict = self._plugin_manager.get_plugins()


### PR DESCRIPTION
Put the aliases in parentheses in the help function output. Created a do_help function in CmdInterpreter that overrides do_help function in https://github.com/python/cpython/blob/3.8/Lib/cmd.py. However, the do_help function in cpython is still called when the user types `help [plugin_name]`.

Fixes issue #617 