### PR TITLE
Passed command in launcher, so that non-interactive mode works

### DIFF
--- a/installer/steps/e_launcher.py
+++ b/installer/steps/e_launcher.py
@@ -21,7 +21,7 @@ else:
     JARVIS_MACRO = """\
     #!/bin/bash
     source {PATH}/env/bin/activate
-    python {PATH}/jarviscli
+    python {PATH}/jarviscli "$@"
     """
 
     fw = open('jarvis', 'w')


### PR DESCRIPTION
You may need to delete the jarvis file and rerun setup.sh for this to work on existing versions of jarvis.
Fixes issue #703