### PR TITLE
NoneType Error and incorrect scores fixed

### DIFF
--- a/jarviscli/plugins/football.py
+++ b/jarviscli/plugins/football.py
@@ -209,10 +209,8 @@ class Football():
         if status != "SCHEDULED":
             # Get the score after 90 mins ordinary time
             scores = match["score"]
-            homeScore = scores["halfTime"]["homeTeam"] + \
-                scores["fullTime"]["homeTeam"]
-            awayScore = scores["halfTime"]["awayTeam"] + \
-                scores["fullTime"]["awayTeam"]
+            homeScore = scores["fullTime"]["homeTeam"]
+            awayScore = scores["fullTime"]["awayTeam"]
             lines.append("SCORE: {} - {}".format(homeScore, awayScore))
             if scores["extraTime"]["homeTeam"] is not None:
                 # Match went on to extra time


### PR DESCRIPTION
I removed scores["halfTime"] variable of the sum. 

In that way, we can fix the NoneType Error and also give the correct score of the match.