### PR TITLE
New feature: Pokemon

### DIFF
--- a/jarviscli/plugins/pokemon.py
+++ b/jarviscli/plugins/pokemon.py
@@ -56,7 +56,7 @@ def pokemon(jarvis, s):
                        'and GAME FREAK, inc. and is protected by various '
                        'copyrights and trademarks. This use is soley for '
                        'educational purposes to learn more about Pokemon.\n',
-                        Fore.YELLOW)
+                      Fore.YELLOW)
             jarvis.say(poke_text, Fore.BLUE)
         except (ValueError, KeyError):
             jarvis.say('Something went wrong. Please try again later.\n', Fore.RED)

--- a/jarviscli/plugins/pokemon.py
+++ b/jarviscli/plugins/pokemon.py
@@ -22,7 +22,7 @@ def parse_species_data(poke_data):
     gen = poke_data['generation']['name']
     is_legendary = 'Yes' if poke_data['is_legendary'] else 'No'
     is_mythical = 'Yes' if poke_data['is_mythical'] else 'No'
-    
+
     # Get random description text (English only)
     # TODO: not just English text
     flavor_texts = [ft for ft in poke_data['flavor_text_entries'] if ft['language']['name'] == 'en']

--- a/jarviscli/plugins/pokemon.py
+++ b/jarviscli/plugins/pokemon.py
@@ -1,0 +1,59 @@
+import random
+import re
+
+import requests
+import pprint
+from colorama import Fore
+
+from plugin import plugin, require
+
+
+def parse_species_data(poke_data):
+    """ Parse and construct text for Jarvis to say about a Pokemon species.
+
+        :param poke_data: dict containing information about a Pokemon species.
+    """
+    template = '{}\nGeneration: {}\nLegendary? {}\nMythical? {}\nDescription: {}\n'
+
+    # Regex to clean description text
+    regex = re.compile(r'[\n\r\t\x0c\xad]')
+
+    # Parse pokemon species data
+    name = poke_data['name']
+    gen = poke_data['generation']['name']
+    is_legendary = 'Yes' if poke_data['is_legendary'] else 'No'
+    is_mythical = 'Yes' if poke_data['is_mythical'] else 'No'
+    
+    # Get random description text (English only)
+    # TODO: not just English text
+    flavor_texts = [ft for ft in poke_data['flavor_text_entries'] if ft['language']['name'] == 'en']
+    try:
+        description = random.choice(flavor_texts)['flavor_text']
+    except IndexError:
+        description = "No description found."
+
+    return template.format(name.title(), gen.title(), is_legendary, is_mythical, regex.sub(' ', description))
+
+
+@require(network=True)
+@plugin('pokemon')
+def pokemon(jarvis, s):
+    """ Get information about a Pokemon species.
+
+        Utilizes PokeApi to obtain the information: https://pokeapi.co/
+    """
+    if not s:
+        jarvis.say('Tell me the name of the pokemon you want to know more about :)\n', Fore.YELLOW)
+        return
+
+    res = requests.get(f'https://pokeapi.co/api/v2/pokemon-species/{s.lower()}/')
+
+    if res.ok:
+        try:
+            poke_data = res.json()
+            poke_text = parse_species_data(poke_data)
+            jarvis.say(poke_text, Fore.BLUE)
+        except (ValueError, KeyError):
+            jarvis.say('Something went wrong. Please try again later.\n', Fore.RED)
+    else:
+        jarvis.say(f'Could not retrieve info about {s}.\n', Fore.RED)

--- a/jarviscli/plugins/pokemon.py
+++ b/jarviscli/plugins/pokemon.py
@@ -51,11 +51,12 @@ def pokemon(jarvis, s):
         try:
             poke_data = res.json()
             poke_text = parse_species_data(poke_data)
-            jarvis.say('DISCLAIMER: This Pokemon fact is the intellectual'
-                       'property of Nintendo, Creatures, inc., and GAME FREAK,'
-                       'inc. and is protected by various copyrights and '
-                       'trademarks. This use is soley for educational '
-                       'purposes to learn more about Pokemon.\n', Fore.YELLOW)
+            jarvis.say('DISCLAIMER: This Pokemon fact is the intellectual '
+                       'property of Nintendo, Creatures, inc., '
+                       'and GAME FREAK, inc. and is protected by various '
+                       'copyrights and trademarks. This use is soley for '
+                       'educational purposes to learn more about Pokemon.\n',
+                        Fore.YELLOW)
             jarvis.say(poke_text, Fore.BLUE)
         except (ValueError, KeyError):
             jarvis.say('Something went wrong. Please try again later.\n', Fore.RED)

--- a/jarviscli/plugins/pokemon.py
+++ b/jarviscli/plugins/pokemon.py
@@ -51,6 +51,11 @@ def pokemon(jarvis, s):
         try:
             poke_data = res.json()
             poke_text = parse_species_data(poke_data)
+            jarvis.say('DISCLAIMER: This Pokemon fact is the intellectual'
+                       'property of Nintendo, Creatures, inc., and GAME FREAK,'
+                       'inc. and is protected by various copyrights and '
+                       'trademarks. This use is soley for educational '
+                       'purposes to learn more about Pokemon.\n', Fore.YELLOW)
             jarvis.say(poke_text, Fore.BLUE)
         except (ValueError, KeyError):
             jarvis.say('Something went wrong. Please try again later.\n', Fore.RED)

--- a/jarviscli/plugins/pokemon.py
+++ b/jarviscli/plugins/pokemon.py
@@ -2,7 +2,6 @@ import random
 import re
 
 import requests
-import pprint
 from colorama import Fore
 
 from plugin import plugin, require

--- a/jarviscli/plugins/wifi_password_getter.py
+++ b/jarviscli/plugins/wifi_password_getter.py
@@ -23,9 +23,8 @@ class wifiPasswordGetter():
                    '\nPassword: ' + strip_password)
 
     def get_wifi_profiles(self):
-        out = subprocess.Popen(
-                               ["ls",
-                                "/etc/NetworkManager/system-connections/"],
+        out = subprocess.Popen(["ls",
+                               "/etc/NetworkManager/system-connections/"],
                                universal_newlines=True,
                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT
                                )
@@ -35,7 +34,7 @@ class wifiPasswordGetter():
 
     def show_options(self, jarvis, arr):
         count = 1
-        for x in range(len(arr)-1):
+        for x in range(len(arr) - 1):
             option = arr[x]
             jarvis.say(str(count) + ": " + option)
             count = count + 1

--- a/jarviscli/tests/test_pokemon.py
+++ b/jarviscli/tests/test_pokemon.py
@@ -8,6 +8,7 @@ from plugins import pokemon
 
 
 class PokemonTest(PluginTest):
+    """ Test suite for the pokemon plugin. Based off test_chuck.py. """
 
     def setUp(self):
         self.test = self.load_plugin(pokemon.pokemon)

--- a/jarviscli/tests/test_pokemon.py
+++ b/jarviscli/tests/test_pokemon.py
@@ -1,0 +1,27 @@
+import unittest
+
+from mock import patch
+import requests
+
+from tests import PluginTest
+from plugins import pokemon
+
+
+class PokemonTest(PluginTest):
+
+    def setUp(self):
+        self.test = self.load_plugin(pokemon.pokemon)
+
+    def test_pokemon(self):
+        with patch.object(requests, 'get') as req_get_mock:
+            self.test.run('Charmander')
+            req_get_mock.assert_called_with("https://pokeapi.co/api/v2/pokemon-species/charmander/")
+
+    def test_pokemon_no_input(self):
+        self.test.run('')
+
+        self.assertEqual(self.history_say().last_text(), 'Tell me the name of the pokemon you want to know more about :)')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello! First off, I'd like to say that this is a really cool project! I've been looking for something like this that I could use as well as contribute to, and i'm glad I found it. :smile: 

With that said, I've created a new plugin that allows Jarvis to give information about a specific [Pokemon](https://en.wikipedia.org/wiki/Pok%C3%A9mon). It adds the `pokemon` command, and users can say the name of the Pokemon they want to know more about. For example, `pokemon zapdos` will result in Jarvis giving information about [Zapdos](https://bulbapedia.bulbagarden.net/wiki/Zapdos_(Pok%C3%A9mon)). The name, generation, description, and whether or not the Pokemon is mythical or legendary is given. Here's a screenshot of it in action:

![image](https://user-images.githubusercontent.com/11671073/96804236-71eca880-13dc-11eb-8989-44faa43aff65.png)

The plugin uses the [PokeAPI](https://pokeapi.co/) REST API to obtain information about the requested Pokemon. It currently displays the information in English, though I think it would be nice to display in other languages.

I also fixed linting errors that I saw in the Travis build logs.