### PR TITLE
Fix directions_to.py and add an example

### DIFF
--- a/jarviscli/packages/directions_to.py
+++ b/jarviscli/packages/directions_to.py
@@ -1,16 +1,21 @@
 from . import mapps
 
 
-def wordIndex(data, word):
-    wordList = data.split()
-    return wordList.index(word)
-
-
 def main(data):
+    """
+    Extracts the names of start(if given) and destination cities,
+    from the given argument.
+
+    Parameters
+    ----------
+    data: str
+        A variable that contains the names of start(if given) and
+        destination cities.
+    """
     word_list = data.split()
-    to_index = wordIndex(data, "to")
-    if " from " in data:
-        from_index = wordIndex(data, "from")
+    to_index = word_list.index("to")
+    if "from" in word_list:
+        from_index = word_list.index("from")
         if from_index > to_index:
             to_city = " ".join(word_list[to_index + 1:from_index])
             from_city = " ".join(word_list[from_index + 1:])

--- a/jarviscli/plugins/converted.py
+++ b/jarviscli/plugins/converted.py
@@ -46,8 +46,9 @@ def check_weather(self, s):
 def directions(self, data):
     """
     Get directions about a destination you are interested to.
-    -- Example:
+    -- Examples:
         directions to the Eiffel Tower
+        directions from the Arc de Triomphe to the Eiffel Tower
     """
     self = self._jarvis
 


### PR DESCRIPTION
While using Jarvis I found a bug in the "directions" command:

If the user enters: "directions from X to Y", the  variable "data" given in the main() function of directions_to.py is  a String in the form: "from X to Y", due to the strip() method. So, the if statement: `if  " from " in data:` is never satisfied, due to the trailling space and the user doesn't get the directions from the start city he wants.

This PR:

- Fixes the previously mentioned bug.
- Adds docstrings to the main() function of directions_to.py.
- Removes the wordIndex() function, which executes an already executed command and embeds its utility in the main() function, since the existance of the wordIndex() is redundant .
- Adds an example of directions with both start and destination city in converted.py.