### PR TITLE
Fix small bugs in "near" command

### DIFF
--- a/jarviscli/packages/mapps.py
+++ b/jarviscli/packages/mapps.py
@@ -77,6 +77,8 @@ def search_near(things, city=0):
         print("{COLOR}Hold on! I'll show {THINGS} near {CITY}{COLOR_RESET}"
               .format(COLOR=Fore.GREEN, COLOR_RESET=Fore.RESET,
                       THINGS=things, CITY=city))
+        url = "https://www.google.com/maps/search/{0}+near+{1}".format(
+            things, city)
     else:
         print("{COLOR}Hold on!, I'll show {THINGS} near you{COLOR_RESET}"
               .format(COLOR=Fore.GREEN, COLOR_RESET=Fore.RESET, THINGS=things))

--- a/jarviscli/packages/near_me.py
+++ b/jarviscli/packages/near_me.py
@@ -4,13 +4,15 @@ from . import mapps
 
 def main(data):
     """
-    Extracts from the given argument, the things and the area to be searched, which can
-    be either a specific area or the user's location.
+    Extracts from the given argument, the things and the area to be
+    searched, which can be either a specific area or the user's
+    location.
 
     Parameters
     ----------
     data: str
-        A variable that contains the things and the area to be searched.
+        A variable that contains the things and the area to be
+        searched.
     """
     word_list = data.split()
     try:

--- a/jarviscli/packages/near_me.py
+++ b/jarviscli/packages/near_me.py
@@ -25,5 +25,4 @@ def main(data):
     else:
         word_list = data.split()
         city = " ".join(word_list[word_list.index("|") + 1:])
-        print(city)
     mapps.search_near(things, city)

--- a/jarviscli/packages/near_me.py
+++ b/jarviscli/packages/near_me.py
@@ -2,24 +2,28 @@ import CmdInterpreter
 from . import mapps
 
 
-def wordIndex(data, word):
-    wordList = data.split()
-    return wordList.index(word)
-
-
 def main(data):
+    """
+    Extracts from the given argument, the things and the area to be searched, which can
+    be either a specific area or the user's location.
+
+    Parameters
+    ----------
+    data: str
+        A variable that contains the things and the area to be searched.
+    """
     word_list = data.split()
     try:
-        things = " ".join(word_list[0:wordIndex(data, "|")])
+        things = " ".join(word_list[0:word_list.index("|")])
     except ValueError:
         cmd = CmdInterpreter.CmdInterpreter("", "")
         cmd.help_near()
         return
 
-    if " me" in data:
+    if "me" in word_list:
         city = 0
     else:
         word_list = data.split()
-        city = " ".join(word_list[wordIndex(data, "|") + 1:])
+        city = " ".join(word_list[word_list.index("|") + 1:])
         print(city)
     mapps.search_near(things, city)


### PR DESCRIPTION
In the "near" command there are two small bugs, specifically :

1. If the user asks for: "things near city", the URL to be opened in the web browser is missing in mapps.py and an error occurs.
2. The if statement: `if ' me' in data`, wrongly interprets some arguments as "me" for example if the user asks, "restaurants near mexico city".

This PR : 

- Fixes the previously mentioned bugs.

Similarly to #838 :

- Adds docstrings to near_me.py.
- Removes the wordIndex() function and embeds its utility in the main() function, since the existence of wordIndex() is redundant.