### PR TITLE
Add tests and fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
       language: shell
       before_install:
         - choco install python --version 3.7.4
+        - python -m pip install --upgrade pip
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 install:
     - if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -33,7 +33,7 @@ speedtest-cli
 sympy
 tabulate
 termdown
-opencv-python
+opencv-python-headless
 whois
 wikipedia
 win10toast; sys_platform == 'win32'

--- a/jarviscli/plugins/file_manager.py
+++ b/jarviscli/plugins/file_manager.py
@@ -3,22 +3,23 @@ import shutil
 
 from plugin import plugin
 
+
 @plugin("file manage")
 class file_manage:
     """"
-    Can manipulate files by deleting, moving, or renaming. 
-    """"
+    Can manipulate files by deleting, moving, or renaming.
+    """
 
     def __call__(self, jarvis, s):
         self.get_file_directory(jarvis)
         self.get_cmd(jarvis)
 
         if self.cmd == "delete":
-            self.delete(jarvis,self.file)
+            self.delete(jarvis, self.file)
         elif self.cmd == "move":
-            self.move(jarvis,self.file)
+            self.move(jarvis, self.file)
         elif self.cmd == "rename":
-            self.rename(jarvis,self.file)
+            self.rename(jarvis, self.file)
 
     def get_file_directory(self, jarvis):
         self.file = jarvis.input("Enter the directory of the file you would like to edit: ")
@@ -103,7 +104,7 @@ class file_manage:
             # get root directory
             root = os.path.split(file)[0]
 
-            new_dir = os.path.join(root,new_name)
+            new_dir = os.path.join(root, new_name)
 
             try:
                 os.rename(file, new_dir)

--- a/jarviscli/plugins/newyear.py
+++ b/jarviscli/plugins/newyear.py
@@ -1,5 +1,6 @@
 from plugin import plugin
 
+
 @plugin("christmas")
 def newyear(jarvis, s):
     tree = "     *\n"\

--- a/jarviscli/tests/test_currencyconv.py
+++ b/jarviscli/tests/test_currencyconv.py
@@ -1,6 +1,6 @@
 import unittest
 from Jarvis import Jarvis
-from plugins.currencyconv import Currencyconv
+from plugins.currency_conv import Currencyconv
 
 from tests import PluginTest
 

--- a/jarviscli/tests/test_directions_to.py
+++ b/jarviscli/tests/test_directions_to.py
@@ -1,0 +1,38 @@
+import unittest
+from mock import patch
+from packages import directions_to, mapps
+
+
+class TestDirectionsTo(unittest.TestCase):
+    """
+    A test class that contains test cases for the main method of
+    directions_to.
+    """
+
+    @patch.object(mapps, 'directions')
+    def test_directions_with_start_and_destination_city(self, mock_directions):
+        from_city = 'London'
+        to_city = 'Manchester'
+        data = "from {} to {}".format(from_city, to_city)
+        directions_to.main(data)
+        mock_directions.assert_called_once_with(to_city, from_city)
+
+    @patch.object(mapps, 'directions')
+    def test_directions_with_destination_and_start_city(self, mock_directions):
+        from_city = 'Madrid'
+        to_city = 'Valencia'
+        data = "to {} from {}".format(to_city, from_city)
+        directions_to.main(data)
+        mock_directions.assert_called_once_with(to_city, from_city)
+
+    @patch.object(mapps, 'directions')
+    def test_directions_with_only_destination_city(self, mock_directions):
+        from_city = 0
+        to_city = 'Paris'
+        data = "to {}".format(to_city)
+        directions_to.main(data)
+        mock_directions.assert_called_once_with(to_city, from_city)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/jarviscli/tests/test_lengthconv.py
+++ b/jarviscli/tests/test_lengthconv.py
@@ -1,6 +1,6 @@
 import unittest
 from tests import PluginTest
-from plugins.lengthconv import lengthconv
+from plugins.length_conv import lengthconv
 from Jarvis import Jarvis
 
 

--- a/jarviscli/tests/test_massconv.py
+++ b/jarviscli/tests/test_massconv.py
@@ -1,6 +1,6 @@
 import unittest
 from tests import PluginTest
-from plugins.massconv import massconv
+from plugins.mass_conv import massconv
 from Jarvis import Jarvis
 
 

--- a/jarviscli/tests/test_near_me.py
+++ b/jarviscli/tests/test_near_me.py
@@ -3,17 +3,36 @@ from mock import patch
 from packages import near_me, mapps
 
 
-class NearMeTest(unittest.TestCase):
-
-    def setUp(self):
-        self.things = 'charities'
-        self.city = 'Valencia'
+class TestNearMe(unittest.TestCase):
+    """
+    A test class that contains test cases for the main method of
+    near_me.
+    """
 
     @patch.object(mapps, 'search_near')
-    def test_what_to_search_where_is_passed_to_mapps(self, mock_search_near):
-        data = "{} | {}".format(self.things, self.city)
+    def test_near_with_things_and_specific_city(self, mock_search_near):
+        things = 'charities'
+        city = 'Valencia'
+        data = "{} | {}".format(things, city)
         near_me.main(data)
-        mock_search_near.assert_called_once_with(self.things, self.city)
+        mock_search_near.assert_called_once_with(things, city)
+
+    @patch.object(mapps, 'search_near')
+    def test_near_with_things_and_my_location(self, mock_search_near):
+        things = 'restaurants'
+        city = 'me'
+        expected_city = 0
+        data = "{} | {}".format(things, city)
+        near_me.main(data)
+        mock_search_near.assert_called_once_with(things, expected_city)
+
+    @patch.object(mapps, 'search_near')
+    def test_near_with_things_and_empty_space(self, mock_search_near):
+        things = 'bars'
+        city = ''
+        data = "{} | {}".format(things, city)
+        near_me.main(data)
+        mock_search_near.assert_called_once_with(things, city)
 
 
 if __name__ == '__main__':

--- a/jarviscli/tests/test_tempconv.py
+++ b/jarviscli/tests/test_tempconv.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from plugins.tempconv import Tempconv
+from plugins.temp_conv import Tempconv
 
 from tests import PluginTest
 


### PR DESCRIPTION
This PR aims to : 

1. Fix the building failure in Travis CI.
2. Add some tests for near_me and directions_to.

## Fix building failure

To fix the building failure in Travis CI I made some changes, specifically : 

### For Linux and macOS :

- Add the test.py file in the custom directory, which is needed for the test_create_plugin.py and was deleted by #840.
- Fix flake8 errors by fixing some styling issues.
- Fix test errors by changing some false imports.

### For Windows : 

- Add the pip upgrade command in the .travis.yml file, in order to fix the cryptography install error.
- Fix the error occurring only in Windows, in test_bulkresize.py when importing the cv2 package :
![image](https://user-images.githubusercontent.com/56679780/117140060-9d057b00-adb5-11eb-900f-b1e697bf10b6.png)

After searching for this issue one feasible solution that I found was to change the opencv-python package in the requirements.txt with the opencv-python-headless version, which is the same with the standard opencv-python package but without the GUI functionality and since we do not use any GUI functionality in the Bulkresizer plugin where the cv2 package is imported, I believe this solves the problem.

## Add tests

After fixing some small bugs in the near_me.py and directions_to.py  with #844 and #838, I also added some unit tests to check their methods more accurately.