### PR TITLE
Fix clear plugin for Windows

### DIFF
--- a/jarviscli/plugins/clear.py
+++ b/jarviscli/plugins/clear.py
@@ -1,15 +1,19 @@
 """
 Jarvis plugin for clearing the terminal
 """
-from plugin import plugin
+from plugin import plugin, require, WINDOWS, UNIX
 import os
 
 
+@require(platform=UNIX)
 @plugin("clear")
-def clear(jarvis, s):
-    if os.name == "posix":
-        # Unix/Linux/MacOS/BSD/etc
-        os.system('clear')
-    elif os.name in ("nt", "dos", "ce"):
-        # DOS/Windows
-        os.system("cls")
+def clear_unix(jarvis, s):
+    # Unix/Linux/MacOS/BSD/etc
+    os.system('clear')
+
+
+@require(platform=WINDOWS)
+@plugin("clear")
+def clear_windows(jarvis, s):
+    # DOS/Windows
+    os.system("cls")

--- a/jarviscli/plugins/clear.py
+++ b/jarviscli/plugins/clear.py
@@ -1,8 +1,15 @@
-import os
+"""
+Jarvis plugin for clearing the terminal
+"""
 from plugin import plugin
+import os
 
 
-@plugin('clear')
+@plugin("clear")
 def clear(jarvis, s):
-    """Clears terminal"""
-    os.system("clear")
+    if os.name == "posix":
+        # Unix/Linux/MacOS/BSD/etc
+        os.system('clear')
+    elif os.name in ("nt", "dos", "ce"):
+        # DOS/Windows
+        os.system("cls")


### PR DESCRIPTION
This PR aims to **fix the clear plugin** in order to work for many Operating Systems.

More specifically, there was a bug in the "clear" plugin as it didn't work for Windows, although it appeared in the --help-- plugin list.

After reviewing it, I added the proper command to correct the functionality.

I also added the needed documentation and formatted the code according to PEP8 instructions.
