### PR TITLE
Create wifi_password_getter for Windows

### DIFF
--- a/jarviscli/plugins/wifi_password_getter.py
+++ b/jarviscli/plugins/wifi_password_getter.py
@@ -114,19 +114,22 @@ class WifiPasswordGetterLINUX:
 class WifiPasswordGetterWINDOWS:
     """
     A Jarvis plugin for Windows, that will find and display all the profiles of the
-    wifis that you have connected to and then display the password if selected.
-
+    wifis that you have connected to and then display the password, if selected or
+    display instantly the password of the requested wifi, e.g. wifi or wifi wifi_name.
     """
 
     def __call__(self, jarvis, s):
-        profiles = self.get_wifi_profiles()
-        if len(profiles) == 0:
-            jarvis.say("No connected wifi found!", Fore.RED)
-            return
-        choice = self.show_options(jarvis, profiles)
-        if choice == -1:
-            return
-        self.display_password(jarvis, profiles[choice - 1])
+        if s:
+            self.display_password(jarvis, s)
+        else:
+            profiles = self.get_wifi_profiles()
+            if len(profiles) == 0:
+                jarvis.say("No connected wifi found!", Fore.YELLOW)
+                return
+            choice = self.show_options(jarvis, profiles)
+            if choice == -1:
+                return
+            self.display_password(jarvis, profiles[choice - 1])
 
     def get_wifi_profiles(self):
         """
@@ -222,4 +225,6 @@ class WifiPasswordGetterWINDOWS:
                            '\nPassword: ' + "UNKNOWN")
 
         except subprocess.CalledProcessError:
-            jarvis.say("Encoding Error Occurred")
+            jarvis.say(
+                "Unable to get the password for this wifi. Make sure you enter the correct wifi name!",
+                Fore.YELLOW)

--- a/jarviscli/plugins/wifi_password_getter.py
+++ b/jarviscli/plugins/wifi_password_getter.py
@@ -1,15 +1,14 @@
-from plugin import LINUX, plugin, require
-from platform import system as sys
+from plugin import LINUX, WINDOWS, plugin, require
 from colorama import Fore
 import subprocess
 
 
 @require(platform=LINUX)
 @plugin("wifi")
-class wifiPasswordGetter():
+class WifiPasswordGetterLINUX:
     """
-    A Jarvis plugin that will find and display all the profiles of the
-    wifis that you have connected to and then display the password if selected
+    A Jarvis plugin for Linux, that will find and display all the profiles of the
+    wifis that you have connected to and then display the password if selected.
 
     """
 
@@ -24,13 +23,29 @@ class wifiPasswordGetter():
                    '\nPassword: ' + strip_password)
 
     def get_wifi_profiles(self):
-        out = subprocess.Popen(["ls", "/etc/NetworkManager/system-connections/"],
-                               universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        """
+        Returns the names of the connected wifis.
+        """
+        out = subprocess.Popen(["ls",
+                                "/etc/NetworkManager/system-connections/"],
+                               universal_newlines=True,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT)
         (res, stderr) = out.communicate()
         data = res.split('\n')
         return data
 
     def show_options(self, jarvis, arr):
+        """
+        Displays the names of the connected wifis and returns the number of the selected.
+
+        Parameters
+        ----------
+        jarvis: JarvisAPI
+            An instance of the JarvisAPI class.
+        arr: list
+            The list with the wifi names.
+        """
         count = 1
         for x in range(len(arr) - 1):
             option = arr[x]
@@ -45,6 +60,20 @@ class wifiPasswordGetter():
             return choice
 
     def get_choice(self, input_text, max_valid_value, terminator, jarvis):
+        """
+        Returns the number of the selected wifi.
+
+        Parameters
+        ----------
+        input_text: str
+            The text to be printed when asking for input.
+        max_valid_value: int
+            The max valid value for the choices.
+        terminator: int
+            The value to terminate the procedure.
+        jarvis: JarvisAPI
+            An instance of the JarvisAPI class.
+        """
         while True:
             try:
                 inserted_value = int(jarvis.input(input_text, Fore.GREEN))
@@ -63,6 +92,14 @@ class wifiPasswordGetter():
             jarvis.say("")
 
     def display_password(self, ssid):
+        """
+        Returns the password of the selected wifi.
+
+        Parameters
+        ----------
+        ssid: str
+            The name of the selected wifi.
+        """
         path = "/etc/NetworkManager/system-connections/"
         display = subprocess.Popen([f"sudo grep -r '^psk=' {path}{ssid}"],
                                    shell=True, universal_newlines=True,
@@ -70,3 +107,119 @@ class wifiPasswordGetter():
                                    stderr=subprocess.STDOUT)
         (new_res, stderr) = display.communicate()
         return new_res
+
+
+@require(platform=WINDOWS)
+@plugin("wifi")
+class WifiPasswordGetterWINDOWS:
+    """
+    A Jarvis plugin for Windows, that will find and display all the profiles of the
+    wifis that you have connected to and then display the password if selected.
+
+    """
+
+    def __call__(self, jarvis, s):
+        profiles = self.get_wifi_profiles()
+        if len(profiles) == 0:
+            jarvis.say("No connected wifi found!", Fore.RED)
+            return
+        choice = self.show_options(jarvis, profiles)
+        if choice == -1:
+            return
+        self.display_password(jarvis, profiles[choice - 1])
+
+    def get_wifi_profiles(self):
+        """
+        Returns the names of the connected wifis.
+        """
+        meta_data = subprocess.check_output(
+            ['netsh', 'wlan', 'show', 'profiles'])
+        data = meta_data.decode('utf-8', errors="backslashreplace")
+        data = data.split('\n')
+        profiles = []
+        for i in data:
+            if "All User Profile" in i:
+                i = i.split(":")
+                i = i[1]
+                i = i[1:-1]
+                profiles.append(i)
+
+        return profiles
+
+    def show_options(self, jarvis, profiles):
+        """
+        Displays the names of the connected wifis and returns the number of the selected.
+
+        Parameters
+        ----------
+        jarvis: JarvisAPI
+            An instance of the JarvisAPI class.
+        profiles: list
+            The list with the wifi names.
+        """
+        count = 1
+        for profile in profiles:
+            jarvis.say(str(count) + ": " + profile)
+            count = count + 1
+        jarvis.say(str(count) + ": Exit")
+        choice = self.get_choice(jarvis, "Please select a number or Exit: ",
+                                 count)
+        return choice
+
+    def get_choice(self, jarvis, input_text, max_valid_value):
+        """
+        Returns the number of the selected wifi.
+
+        Parameters
+        ----------
+        jarvis: JarvisAPI
+            An instance of the JarvisAPI class.
+        input_text: str
+            The text to be printed when asking for input.
+        max_valid_value: int
+            The max valid value for the choices.
+        """
+        while True:
+            try:
+                inserted_value = int(jarvis.input(input_text, Fore.GREEN))
+                if inserted_value == max_valid_value:
+                    return -1
+                elif max_valid_value > inserted_value >= 1:
+                    return inserted_value
+                else:
+                    jarvis.say(
+                        "Invalid input! Enter a number from the"
+                        " choices provided.", Fore.YELLOW)
+            except ValueError:
+                jarvis.say(
+                    "Invalid input! Enter a number from the choices provided.",
+                    Fore.YELLOW)
+
+    def display_password(self, jarvis, profile):
+        """
+        Displays the name and the password of the selected wifi.
+
+        Parameters
+        ----------
+        profile: str
+            The name of the selected wifi.
+        jarvis: JarvisAPI
+            An instance of the JarvisAPI class.
+        """
+        try:
+            results = subprocess.check_output(
+                ['netsh', 'wlan', 'show', 'profile', profile, 'key=clear'])
+            results = results.decode('utf-8', errors="backslashreplace")
+            results = results.split('\n')
+            results = [b.split(":")[1][1:-1]
+                       for b in results if "Key Content" in b]
+            try:
+                jarvis.say("Wifi Name: " + profile +
+                           '\nPassword: ' + results[0])
+
+            except IndexError:
+                jarvis.say("Wifi Name: " + profile +
+                           '\nPassword: ' + "UNKNOWN")
+
+        except subprocess.CalledProcessError:
+            jarvis.say("Encoding Error Occurred")

--- a/jarviscli/tests/test_wifi_password_getter.py
+++ b/jarviscli/tests/test_wifi_password_getter.py
@@ -1,0 +1,66 @@
+import unittest
+from tests import PluginTest
+from plugins import wifi_password_getter
+from colorama import Fore
+
+
+class TestWifiPasswordGetter(PluginTest):
+    """
+    A test class that contains test cases for the methods of
+    the wifi_password_getter plugin for Windows.
+    """
+
+    def setUp(self):
+        self.test = self.load_plugin(
+            wifi_password_getter.WifiPasswordGetterWINDOWS)
+
+    def test_show_options_last_text(self):
+        self.queue_input("2")
+        profiles = ["profile_1", "profile_2", "profile_3"]
+        self.test.show_options(self.jarvis_api, profiles)
+        self.assertEqual(self.history_say().last_text(), "4: Exit")
+
+    def test_get_choice_valid(self):
+        self.queue_input("2")
+        input_text = "Please select a number or Exit: "
+        max_valid_value = 3
+        self.assertEqual(
+            self.test.get_choice(
+                self.jarvis_api,
+                input_text,
+                max_valid_value),
+            2)
+
+    def test_get_choice_terminator(self):
+        self.queue_input("3")
+        input_text = "Please select a number or Exit: "
+        max_valid_value = 3
+        self.assertEqual(
+            self.test.get_choice(
+                self.jarvis_api, input_text, max_valid_value), -1)
+
+    def test_get_choice_invalid(self):
+        self.queue_input("7")
+        self.queue_input("2")
+        input_text = "Please select a number or Exit: "
+        max_valid_value = 3
+        self.test.get_choice(self.jarvis_api, input_text, max_valid_value)
+        self.assertEqual(
+            self.history_say().last_text(),
+            "Invalid input! Enter a number from the choices provided.")
+        self.assertEqual(self.history_say().last_color(), Fore.YELLOW)
+
+    def test_get_choice_exception(self):
+        self.queue_input("wrong_input")
+        self.queue_input("2")
+        input_text = "Please select a number or Exit: "
+        max_valid_value = 3
+        self.test.get_choice(self.jarvis_api, input_text, max_valid_value)
+        self.assertEqual(
+            self.history_say().last_text(),
+            "Invalid input! Enter a number from the choices provided.")
+        self.assertEqual(self.history_say().last_color(), Fore.YELLOW)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR:
1.  Implements the wifi_password_getter plugin for Windows.
2.  Adds the new functionality that enables asking instantly for the password of a specific wifi.
3.  Adds documentation to the entire file.
4.  Makes small changes to be according to the PEP8 guidelines.
5.  Creates test cases for the Windows plugin.

