### PR TITLE
Bug-Fix: First Reaction Logical Control

### DIFF
--- a/jarviscli/CmdInterpreter.py
+++ b/jarviscli/CmdInterpreter.py
@@ -361,8 +361,9 @@ class CmdInterpreter(Cmd):
         if (not command):
             self._init_plugin_info()
         self._activate_plugins()
-
-        self._api.say(self.first_reaction_text)
+        
+        if self.first_reaction:
+            self._api.say(self.first_reaction_text)
 
     def _init_plugin_info(self):
         plugin_status_formatter = {


### PR DESCRIPTION
In the Jarvis API, the first_reaction boolean value has no effect.

As can be seen in the image, when the `first_reaction` is set to `False` value, it has no effect.

![fix:first_reaction_control](https://user-images.githubusercontent.com/35719856/129703687-69b5fa53-7dce-4475-9ca4-746945fd5e22.png)

So I have added a logical control for the boolean value of `first_reaction` in the constructor of class of  the `CmdInterpreter`.