### PR TITLE
"no module named" error fix

### DIFF
--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -44,3 +44,5 @@ Image
 img2pdf
 pdf2image
 python-nmap
+PyPDF2
+fasttext


### PR DESCRIPTION
Updated requirements.txt to fix the "no module named" error upon a fresh installation of Jarvis on Windows 10