### PR TITLE
Twitter trends plugin

### DIFF
--- a/jarviscli/plugins/twitter_trends.py
+++ b/jarviscli/plugins/twitter_trends.py
@@ -1,19 +1,142 @@
+# -*- coding: utf-8 -*-
+"""Twitter Trends plugin.
 
-class Trend:
-    pass
+    This plugin prints a list of countries with their unique id and returns
+    the top 10 trends in Twitter for this specific country.
 
+    Typical usage example:
 
-def available_countries():
-    pass
+    >twitter trends
+    >number_of_country
 
+    @Author: Leonidha Mara @leonidhaMara & Emmanouil Manousakis @manousakis01
+    @Date: 7th May, 2022
+"""
+from colorama import Fore
+from plugin import plugin, require, alias
+import requests
+import json
 
-def show_countries():
-    pass
+@alias("trendtwit")
+@require(network=True)
+@plugin("twitter trends")
+class TwitterTrends:
+    def __call__(self, jarvis, s):
+        self.jarvis = jarvis
+        self.main()
 
+    def __init__(self):
+        self.countries = self.available_countries()
+        self.exit_msg = "exit"
 
-def get_country():
-    pass
+    def main(self):
+        self.display_countries()
+        self.jarvis.say("To exit enter word 'exit'", color=Fore.YELLOW)
+        while True:
+            country_code = self.get_country()
+            if self.is_exit_input(country_code):
+                break
+            retrivied_trends = self.get_trends_from(country_code)
+            self.display_trends(retrivied_trends)
+            if self.is_end():
+                break
 
+    def is_end(self):
+        inp = self.jarvis.input(
+            "Do you want to continue? (Y/N) ", color=Fore.RED)
+        if inp.lower() == "n":
+            return True
 
-def get_trends(country: int):
-    pass
+    def is_out_of_range(self, x: int) -> bool:
+        upper_bound = len(self.countries) - 1
+        return (True if (x > upper_bound or x < 0) else False)
+
+    def available_countries(self):
+        """
+        Return a dictionary of the supported countries.
+        Key: number of country,
+        Value: [country name, country url suffix]
+        """
+        URL = "http://api-twitter-trends.herokuapp.com/location"
+        json_text = self.get_json(URL)
+        countries_response = json_text["data"]
+        countries = dict()
+        # add countries
+        for key, country in enumerate(countries_response):
+            countries[key] = [country["location_path"],
+                              country["location_url"]]
+        # add worldwide option in the end
+        countries[len(countries_response)] = ["worldwide", "/trends?location="]
+        return countries
+
+    def get_json(self, URL: str):
+        """
+        Return data from given url in json format
+        """
+        try:
+            response = requests.get(URL)
+        except Exception:
+            self.jarvis.say(
+                "Can not reach URL for the moment.")
+        return json.loads(response.text)
+
+    def get_country(self):
+        """
+        Get user input and validate it.
+        Input must be a number that corresponds to a country.
+        """
+        country_code = None
+        # Until country code is valid
+        while not country_code:
+            try:
+                country_code = self.jarvis.input(
+                    "Choose country: ", color=Fore.GREEN)
+                if self.is_valid_input(int(country_code)):
+                    raise ValueError
+            except ValueError:
+                if self.is_exit_input(country_code):
+                    return 'exit'
+                self.jarvis.say(
+                    f"Please select a number (0 - {len(self.countries) - 1})", color=Fore.YELLOW)
+                country_code = None
+        return int(country_code)
+
+    def is_exit_input(self, input):
+        if (type(input) == str and input.lower() == "exit"):
+            return True
+
+    def is_valid_input(self, input):
+        if type(input) == int and self.is_out_of_range(input):
+            return True
+
+    def get_trends_from(self, country: int):
+        """
+        Get the top 10 Twitter trends of the given country.
+        """
+        URL = f"https://api-twitter-trends.herokuapp.com{self.countries[country][1]}"
+        json_text = self.get_json(URL)
+        trends = list()
+        # zero stands for the latest trends ranking
+        trends_info = json_text["data"]["trends"][0]["data"]
+        for trend in trends_info:
+            name = trend["name"]
+            tweet_count = "-"
+            if trend["tweet_count"]:
+                tweet_count = trend["tweet_count"]
+            trends.append([name, tweet_count])
+        return trends
+
+    def display_countries(self):
+        """
+        Display available countries to the user.
+        """
+        # order in the list
+        country_name_position = 0
+        for country_key in self.countries:
+            self.jarvis.say(
+                f"{country_key:{2}}{'.':{2}}{self.countries[country_key][country_name_position].upper()}")
+
+    def display_trends(self, trends):
+        self.jarvis.say(f"     {'Trend':{24}}{'Tweets':{23}}")
+        for i, v in enumerate(trends):
+            self.jarvis.say(f"{i + 1:{2}}{'.':{3}}{v[0]:{25}}{v[1]:{25}}")

--- a/jarviscli/plugins/twitter_trends.py
+++ b/jarviscli/plugins/twitter_trends.py
@@ -1,0 +1,19 @@
+
+class Trend:
+    pass
+
+
+def available_countries():
+    pass
+
+
+def show_countries():
+    pass
+
+
+def get_country():
+    pass
+
+
+def get_trends(country: int):
+    pass

--- a/jarviscli/tests/test_twitter_trends.py
+++ b/jarviscli/tests/test_twitter_trends.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest import mock
+import requests
+from tests import PluginTest
+from plugins.twitter_trends import TwitterTrends
+
+
+class TwitterTrendsTest(PluginTest):
+    def setUp(self):
+        self.test = self.load_plugin(TwitterTrends)
+        self.test.jarvis = self.jarvis_api
+
+    def test_available_countries(self):
+        response = requests.get(
+            "http://api-twitter-trends.herokuapp.com/location")
+        self.assertTrue(response.ok)
+
+    def test_sample_countries(self):
+        # Test Greece country
+        response = requests.get(
+            f"http://api-twitter-trends.herokuapp.com/trends?location=greece")
+        self.assertTrue(response.ok)
+
+    def test_is_out_of_range_true(self):
+        self.assertTrue(self.test.is_out_of_range(700))
+        self.assertTrue(self.test.is_out_of_range(-10))
+
+    def test_is_out_of_range_false(self):
+        self.assertFalse(self.test.is_out_of_range(10))
+        self.assertFalse(self.test.is_out_of_range(50))
+
+    def test_is_exit_input(self):
+        self.assertTrue(self.test.is_exit_input('exit'))
+        self.assertFalse(self.test.is_exit_input('random'))
+
+    def test_get_country_exit(self):
+        PluginTest.queue_input(self, 'exit')
+        result = self.test.get_country()
+        self.assertEqual(result, 'exit')
+
+    def test_get_country_number(self):
+        PluginTest.queue_input(self, '-10')
+        PluginTest.queue_input(self, '10')
+        self.assertEqual(self.test.get_country(), 10)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
_Hi! Me and my colleague @Manousakis01 implemented the twitter trend plugin.
Pull request implements the feature described in [this issue](https://github.com/sukeesh/Jarvis/issues/965)._

## Twitter Trends
A plugin that displays the *current* Trending Topics in the Twitter, based on a selected country. 

###  Facts about plugin
- Provide: Hashtag or Trending Topic and Tweets count
- No need for API Key
- Support for 60+ countries
- Data refresh each hour
- Exit plugin at any time with <code> exit</code> keyword

### Main Flow
  #### 1. User chooses a country (number)
![image](https://user-images.githubusercontent.com/72790158/167274776-700ec45c-4659-4771-a589-b340944db67d.png)

  #### 2. Trends and Tweets Count (if available)
![image](https://user-images.githubusercontent.com/72790158/167275392-52db8690-b4f0-46c3-900d-f0e57c6d64e6.png)

  #### 3 Get out of plugin
User can continue searching for another country or stop the project
![image](https://user-images.githubusercontent.com/72790158/167275454-633f6b08-2d99-453a-892b-5ad6ec279e7e.png)

### Testing
Provided unittest for some methods and validation for the input given by the user.



