### PR TITLE
fix bug regarding data type of variable type

### DIFF
--- a/jarviscli/plugins/personality.py
+++ b/jarviscli/plugins/personality.py
@@ -58,7 +58,7 @@ class personality_test:
                 self.type.append(personality_type[0])
             else:
                 self.type.append(personality_type[1])
-        self.type = ''.join(self.type)
+        # self.type = ''.join(self.type)
 
     def open_analysis(self):
         url = "https://www.16personalities.com/{}-personality"
@@ -85,12 +85,13 @@ class personality_test:
             self.answers[Q_id] = user_input
         self.get_scores()
 
+        type_str = ''.join(self.type)
         jarvis.say(
             "{}Your personality is: {}{}{}{}".format(
                 Fore.BLUE,
                 Fore.BLACK,
                 Back.MAGENTA,
-                self.type,
+                type_str,
                 Style.RESET_ALL))
         jarvis.say(
             "Redirecting to your personality analysis\


### PR DESCRIPTION
This commit fixes #1052 
The list 'type' was being converted to string in the last line here:
<img width="248" alt="image" src="https://user-images.githubusercontent.com/30435104/220392954-4b0db41f-59df-489b-b96b-5160d5f38f96.png">

I commented that line and created a temporary variable 'type_str' for jarvis.say() under the __call__ method.
