### PR TITLE
Fixed typo on history call

### DIFF
--- a/jarviscli/tests/__init__.py
+++ b/jarviscli/tests/__init__.py
@@ -232,7 +232,7 @@ class PluginTest(unittest.TestCase):
         """
         self.jarvis_api.queue_input(msg)
 
-    def histroy_call(self):
+    def history_call(self):
         """
         Returns MockHistory instance. Fields:
 


### PR DESCRIPTION
Changed  
def histroy_call(self):  
to
def history_call(self):
