### PR TITLE
Issue#1054: Fix Typo in jarviscli/tests/__init__.py

### DIFF
--- a/jarviscli/tests/__init__.py
+++ b/jarviscli/tests/__init__.py
@@ -232,7 +232,7 @@ class PluginTest(unittest.TestCase):
         """
         self.jarvis_api.queue_input(msg)
 
-    def histroy_call(self):
+    def history_call(self):
         """
         Returns MockHistory instance. Fields:
 


### PR DESCRIPTION
This fixes issue# 1054