### PR TITLE
Fix bug regarding Jarvis quote of the day

### DIFF
--- a/jarviscli/plugins/quote.py
+++ b/jarviscli/plugins/quote.py
@@ -25,11 +25,14 @@ class Quote():
 
     def get_quote_of_the_day(self, jarvis):
         res = requests.get(
-            'https://www.brainyquote.com/quotes_of_the_day.html')
-        soup = BeautifulSoup(res.text, 'html.parser')
-
-        quote = soup.find('img', {'class': 'p-qotd'})
-        jarvis.say(quote['alt'])
+            'https://quotes.rest/qod')
+        if res.status_code == 200:
+            data = res.text
+            parse_json = json.loads(data)
+            quote = parse_json['contents']['quotes'][0]['quote']
+            jarvis.say(quote)
+        else:
+            jarvis.say('Sorry, something went wrong. Please try again later or report this issue if it sustains.')
 
     def get_keyword_quotes(self, jarvis, keyword):
         """


### PR DESCRIPTION
I fixed the bug by changing the API being used. It is now using `quotes.rest` rest API.
This commit fixes issue #1063 

![image](https://user-images.githubusercontent.com/58373047/227598469-6eb05019-1681-47db-9e5f-541f90c5ab5b.png)
