### PR TITLE
Fix Bug Regarding Jarvis Typingtest

### DIFF
--- a/jarviscli/plugins/typing_test.py
+++ b/jarviscli/plugins/typing_test.py
@@ -2,8 +2,6 @@ import time
 import sys
 import requests
 import json
-import re
-import curses
 from plugin import plugin, require, UNIX
 import os
 import csv
@@ -20,7 +18,7 @@ class GameState (object):
 default_text_color = Fore.WHITE
 incorrect_color = Fore.RED
 correct_color = Fore.GREEN
-n_words = 4
+n_words = 10
 
 total_time = 100
 
@@ -85,15 +83,12 @@ class Letter():
 
 
 def get_text():
-    response = requests.get('http://www.randomtext.me/api/\
-        gibberish/p-5/' + str(n_words))
-    json_data = json.loads(response.content)
-    random_text = json_data['text_out']
-    clean_text = random_text
-    clean_text = re.sub(re.compile('<.*?>'), '', random_text)
-    clean_text = clean_text.replace('\r', '').replace('\\r', '')
-    clean_text = clean_text.replace('.', '. ')
-    return clean_text
+    response = requests.get(f"https://random-word-api.vercel.app/api?words={n_words}")
+    if response.status_code == 200:
+        json_data = json.loads(response.content)
+        json_data = ' '.join(json_data)
+        print('json_data', json_data)
+        return json_data 
 
 
 def format_time(seconds):


### PR DESCRIPTION
I have made the following changes:

1. Fixed issue #1065 by changing the random-words API being used. It seems like the previous API is no longer supported.
2. Changed the number of words required for the typing test from 4 to 10, as 4 words are not sufficient for conclusive results
3. Removed unused imports