### PR TITLE
Fix #1110 akinator

### DIFF
--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -1,4 +1,4 @@
-akinator.py==0.2.1
+akinator.py
 archey4==4.6.0.post1; sys_platform != 'darwin'
 beautifulsoup4
 climage


### PR DESCRIPTION
Version 0.2.1 was specified in requirements.txt, which proved incompatible. The version is no longer specified so pip can install the latest version.