### PR TITLE
Fix #1116 evaluator plugin plotting

### DIFF
--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -10,6 +10,7 @@ geopy
 gitpython
 googletrans==3.1.0a0
 IMDbPY
+matplotlib
 mock
 nltk
 pathlib2; python_version < '3.4'

--- a/jarviscli/plugins/evaluator.py
+++ b/jarviscli/plugins/evaluator.py
@@ -116,7 +116,13 @@ def plot(jarvis, s):
         plot y=x(x+1)(x-1)
     """
     def _plot(expr):
-        sympy.plotting.plot(expr)
+        plots = sympy.plot(expr[0], show=False)
+
+        for i in range(1, len(expr)):
+            expr[i] = sympy.plot(expr[i], show=False)
+            plots.append(expr[i][0])
+
+        plots.show()
         return ""
 
     if len(s) == 0:
@@ -169,7 +175,7 @@ def limit(jarvis, s):
     term = format_expression(term)
 
     try:
-        term = solve_y(term)
+        term = solve_y(jarvis, term)
     except (sympy.SympifyError, TypeError):
         jarvis.say('Error, not a valid term')
         return
@@ -249,7 +255,7 @@ def solve_y(jarvis, s):
     if len(results) == 0:
         return '0'
     else:
-        return results[0]
+        return results
 
 
 def calc(jarvis, s, calculator=sympy.sympify, formatter=None, do_evalf=True):
@@ -267,7 +273,7 @@ def calc(jarvis, s, calculator=sympy.sympify, formatter=None, do_evalf=True):
     if formatter is not None:
         if 'x' in s and '=' in s and 'y' not in s:
             x = sympy.Symbol('x')
-            result = sympy.plotting.plot_implicit(sympy.Eq(x, result), (x, result - 5, result + 5))
+            result = sympy.plotting.plot_implicit(sympy.Eq(x, result[0]), (x, result[0] - 5, result[0] + 5))
         else:
             result = formatter(result)
 
@@ -301,7 +307,7 @@ def curvesketch(jarvis, s):
 
     term = remove_equals(jarvis, s)
     term = format_expression(term)
-    term = solve_y(term)
+    term = solve_y(jarvis, term)
 
     def get_y(x_val, func=term):
         x = sympy.Symbol('x')

--- a/jarviscli/plugins/evaluator.py
+++ b/jarviscli/plugins/evaluator.py
@@ -123,7 +123,6 @@ def plot(jarvis, s):
         jarvis.say("Missing parameter: function (e.g. call 'plot x**2')")
         return
 
-    s = remove_equals(jarvis, s)
     try:
         calc(jarvis, s, calculator=solve_y, formatter=_plot, do_evalf=False)
     except ValueError:
@@ -232,25 +231,32 @@ def format_expression(s):
     return s
 
 
-def solve_y(s):
+def solve_y(jarvis, s):
     if 'y' in s:
-        y = sympy.Symbol('y')
-        try:
-            results = sympy.solve(s, y)
-        except NotImplementedError:
-            return 'unknown'
-        if len(results) == 0:
-            return '0'
-        else:
-            return results[0]
+        symbol = sympy.Symbol('y')
+    elif 'x' in s and '=' in s:
+        symbol = sympy.Symbol('x')
     else:
-        return solve_y("({}) -y".format(s))
+        return solve_y(jarvis, "({}) -y".format(s))
+    
+    s = remove_equals(jarvis, s)
+
+    try:
+        results = sympy.solve(s, symbol)
+    except NotImplementedError:
+        return 'unknown'
+    
+    if len(results) == 0:
+        return '0'
+    else:
+        return results[0]
 
 
 def calc(jarvis, s, calculator=sympy.sympify, formatter=None, do_evalf=True):
     s = format_expression(s)
+
     try:
-        result = calculator(s)
+        result = calculator(jarvis, s)
     except sympy.SympifyError:
         jarvis.say("Error: Something is wrong with your expression", Fore.RED)
         return
@@ -259,7 +265,11 @@ def calc(jarvis, s, calculator=sympy.sympify, formatter=None, do_evalf=True):
         return
 
     if formatter is not None:
-        result = formatter(result)
+        if 'x' in s and '=' in s and 'y' not in s:
+            x = sympy.Symbol('x')
+            result = sympy.plotting.plot_implicit(sympy.Eq(x, result), (x, result - 5, result + 5))
+        else:
+            result = formatter(result)
 
     if do_evalf:
         result = result.evalf()


### PR DESCRIPTION
Matplotlib was added to installer for improved plot rendering. Issue with graphing vertical lines (x=const) was fixed by using implicit plotting from sympy.
![x=3](https://github.com/sukeesh/Jarvis/assets/109991883/9f0c01a3-b015-4ddb-b41e-a78844e93125)

During debugging, it was discovered that equations such as x=y^2 led to multiple results that had to be plotted separately. Previously, only the first element in the results list was being returned, so the resulting plot was incomplete. Now, all plots returned in results will be plotted.
![x=y^2](https://github.com/sukeesh/Jarvis/assets/109991883/ef68ba4a-95fa-4d45-820c-0c3f1443af89)
