### PR TITLE
Add XDG $HOME/.local/bin install support

### DIFF
--- a/installer/helper.py
+++ b/installer/helper.py
@@ -123,6 +123,13 @@ def user_input(items):
         else:
             log("> User input {} - out of range {} - {}".format(number, 1, len(items)))
 
+def confirm_user_input(confirmation_message : str) -> bool:
+    log("User Confirmation")
+    printlog(confirmation_message)
+    confirm = input("input 'y' to confirm, 'n' to cancel: ")
+    confirm_bool = True if confirm in ['y', 'Y', 'yes', 'YES'] else False;
+    log("User chose to {} the operation.".format("cancel" if confirm_bool == False else "confirm"))
+    return confirm_bool
 
 def shell(cmd):
     class Fail:

--- a/installer/steps/e_launcher.py
+++ b/installer/steps/e_launcher.py
@@ -2,6 +2,32 @@ from helper import *
 from os.path import expanduser, exists
 import unix_windows
 
+def supported_shell_install(rc_line_to_add : str, confirm_addition: bool) -> bool:
+    shell_rc = '{}/.{}rc'.format(expanduser("~"), user_shell)
+    if not os.path.exists(shell_rc):
+        print("NO .{}rc found!".format(user_shell))
+        return False;
+    line_already_exists = False
+
+    with open(shell_rc, "r") as fr:
+        for line in fr.readlines():
+            if line.startswith(rc_line_to_add):
+                line_already_exists = True
+
+    if line_already_exists:
+        print("Jarvis path already added to $PATH in .{}rc!".format(user_shell))
+        return True;
+
+    print("")
+    if (not confirm_user_input("Allow Jarvis installation to add {} to .{}rc?".format(rc_line_to_add, user_shell))):
+        print('Jarvis will not add "{}" to .{}rc.'.format(shell_rc, user_shell))
+        print('In order to use Jarvis please manually add \'{}\' to your $PATH'.format(rc_line_to_add))
+        return False
+    with open(shell_rc, 'a') as fw:
+        fw.write(line_to_add)
+        fw.write('\n')
+    return True
+
 # TODO Windows Install options?
 if unix_windows.IS_WIN:
     fw = open('jarvis.bat', 'w')
@@ -32,11 +58,15 @@ python "{PATH}/jarviscli" "$@"
     user_shell = get_default_shell()
     _do_nothing_str = "Do nothing (Call Jarvis by full path)"
     install_options = [("Install jarvis /usr/local/bin starter (requires root)", 0), ]
+    home = os.getenv("HOME")
+    xdg_install_path = "{}/.local/bin".format(home)
     if user_shell in SUPPORTED_SHELLS:
         install_options += [
             ("Add {} to $PATH (.{}rc)".format(os.getcwd(), user_shell, ), 1),
-            (_do_nothing_str, 2)
         ]
+        if home != None and os.path.exists(xdg_install_path):
+            install_options += [("Install jarvis to {}/.local/bin".format(home), 2)]
+        install_options += [(_do_nothing_str, 3)]
     else:
         install_options += [
             (_do_nothing_str, 1)
@@ -45,30 +75,18 @@ python "{PATH}/jarviscli" "$@"
 
     if selection == 0:
         os.system('sudo cp jarvis /usr/local/bin')
-    elif selection == 1 and user_shell in SUPPORTED_SHELLS:
-        line_to_add = 'export PATH="$PATH:{}"'.format(os.getcwd())
-        shell_rc = '{}/.{}rc'.format(expanduser("~"), user_shell)
-
-        if not os.path.exists(shell_rc):
-            print("NO .{}rc found!".format(user_shell))
-        else:
-            line_already_exists = False
-
-            fr = open(shell_rc)
-            for line in fr.readlines():
-                if line.startswith(line_to_add):
-                    line_already_exists = True
-
-            if line_already_exists:
-                print("Jarvis path already added to $PATH in .{}rc!".format(user_shell))
-            else:
-                fw = open(shell_rc, 'a')
-                fw.write(line_to_add)
-                fw.write('\n')
-                fw.close()
+    elif user_shell in SUPPORTED_SHELLS:
+        if selection == 1:
+            line_to_add = 'export PATH="$PATH:{}"'.format(os.getcwd())
+            supported_shell_install(line_to_add, True)
+        elif selection == 2:
+            os.system('cp jarvis {}'.format(xdg_install_path))
+            line_to_add = 'export PATH="$PATH:{}"'.format(xdg_install_path)
+            supported_shell_install(line_to_add, True)
 
     printlog('\n\nInstallation complete. Try using Jarvis!')
     if selection == 0 or (selection == 1 and user_shell in SUPPORTED_SHELLS):
         printlog('$ jarvis')
     else:
         printlog('$ {}/jarvis'.format(os.getcwd()))
+


### PR DESCRIPTION
Add another installation option. Allow the ability to install Jarvis into `$HOME/.local/bin` to follow XDG guidelines.
#1127 