### PR TITLE
fix: ask user again for valid column input in connect_four instead of throwing error

### DIFF
--- a/jarviscli/plugins/connect_four.py
+++ b/jarviscli/plugins/connect_four.py
@@ -228,7 +228,15 @@ def game(jarvis, s):
 
         printBoard()
         while True:
-            column = int(input('Pick a column (1-7):\n'))
+
+            # Make sure column is numeric. If not then ask user for numeric input again instead of throwing error.
+            notNumericInputFlag = True
+            while notNumericInputFlag == True:
+                try:
+                    column = int(input('Pick a column (1-7):\n'))
+                    notNumericInputFlag = False
+                except ValueError:
+                    print("Enter a valid numeric input.")
             column -= 1
 
             # Make sure column is inbounds

--- a/jarviscli/plugins/evaluator.py
+++ b/jarviscli/plugins/evaluator.py
@@ -262,7 +262,7 @@ def calc(jarvis, s, calculator=sympy.sympify, formatter=None, do_evalf=True):
     s = format_expression(s)
 
     try:
-        result = calculator(jarvis, s)
+        result = calculator(s)
     except sympy.SympifyError:
         jarvis.say("Error: Something is wrong with your expression", Fore.RED)
         return


### PR DESCRIPTION
FIX: #1129 , #1131

Added the `ValueError` throwing code in a `while` loop in a `try-except` block till the user enters a numeric input.

## After fix
![Screenshot 2023-08-26 200509](https://github.com/sukeesh/Jarvis/assets/130159643/86bdbbf7-b44a-4a47-9633-a7dbc82cc710)