### PR TITLE
Add Geolocation plugin

### DIFF
--- a/jarviscli/plugins/geolocation.py
+++ b/jarviscli/plugins/geolocation.py
@@ -1,0 +1,15 @@
+import json
+import requests
+
+@require(network=True)
+@plugin('geolocation')
+def geolocation(jarvis, s):
+    """ Helps to geolocate an IP address """
+    base_url = "https://api.ip2location.io/"
+    payload = {'ip': s, 'format': 'json'}
+    jarvis.say(f'Lookup {s} now...')
+    api_result = requests.get(base_url, params=payload)
+    api_result_json = api_result.json()
+    jarvis.say(f'It\'s located at {api_result_json['city_name']}, {api_result_json['region_name']}, {api_result_json['country_name']}.')
+    jarvis.say(f'It\'s coordinates are ({api_result_json['latitude']}, {api_result_json['longitude']}).')
+    jarvis.say(f'It\'s owned by {api_result_json['as']} with the ASN {api_result_json['asn']}.')


### PR DESCRIPTION
This plugin will helps to geolocate an IP address without an API key, by just entering an IP address.

A quick example would be:

```
geolocation 8.8.8.8
Lookup 8.8.8.8 now...
It's located at Mountain View, California, United States of America.
It's coordinates are (37.38605, -122.08385).
It's owned by Google LLC with the ASN 15169.
```