### PR TITLE
Update pyreadline to pyreadline3

### DIFF
--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -23,7 +23,7 @@ pyjokes
 markdown
 pync; sys_platform == 'darwin'
 pypiwin32; sys_platform == 'win32'
-pyreadline; sys_platform == 'win32'
+pyreadline3; sys_platform == 'win32'
 python-dateutil
 pytimeparse
 pyttsx3 == 2.71; sys_platform != 'darwin'

--- a/jarviscli/plugins/imgur.py
+++ b/jarviscli/plugins/imgur.py
@@ -9,7 +9,7 @@ from plugin import plugin, require
 from utilities.GeneralUtilities import IS_WIN
 
 if IS_WIN:
-    from pyreadline import Readline
+    from pyreadline3 import Readline
     readline = Readline()
 else:
     import readline


### PR DESCRIPTION
Fixes #1157 deprecated 'collections.Callable' call in the previous version of pyreadline.
Since pyreadline is deprecated, I've replaced it with a Python 3 compatible and maintained pyreadline3 with the same functionality. Plugin imgur.py's import of pyreadline is also updated to the new pyreadline3.

(See pyreadline3 here: [https://github.com/pyreadline3/pyreadline3](https://github.com/pyreadline3/pyreadline3))