### PR TITLE
Issue #1235: Fix playsound installation on Python 3.12+

### DIFF
--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -39,7 +39,8 @@ whois
 wikipedia
 win10toast; sys_platform == 'win32'
 gtts
-playsound
+playsound ; python_version < "3.12"
+git+https://github.com/taconi/playsound.git#egg=playsound ; python_version >= "3.12"
 windows-curses; sys_platform == 'win32'
 Image
 img2pdf


### PR DESCRIPTION
- Updates installer/requirements.txt to install a forked version of playsound when running Python 3.12 or newer.
- Fixes issue #1235 where the default playsound package fails to build on Python 3.12+.
- Uses environment markers to ensure compatibility with older Python versions.
