### PR TITLE
Generalize Task Count in README for Better Future Accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Personal Non-AI Assistant for Linux, MacOS and Windows
 
 Jarvis is a simple personal assistant for Linux, MacOS and Windows which works on the command line. He can talk to you if you enable his voice. He can tell you the weather, he can find restaurants and other places near you. He can do some great stuff for you.
 
-## 🚀 20 Different Tasks That Jarvis Can Do For You:
+## 🚀 15+ Different Tasks That Jarvis Can Do For You:
 
 1. **Entertainment & Suggestions**
    - Suggest activities if you're bored (`activity`, `bored`)


### PR DESCRIPTION
This PR updates the number of tasks mentioned in the README for Jarvis (fixes #1237).
Instead of using a fixed number like "20", it now uses a more flexible format like "15+", which stays accurate even if more tasks or plugins are added in the future.

This ensures the documentation remains valid and doesn't require frequent updates as the project evolves.