### PR TITLE
Fix AttributeError in personality plugin

### DIFF
--- a/jarviscli/plugins/personality.py
+++ b/jarviscli/plugins/personality.py
@@ -62,7 +62,7 @@ class personality_test:
 
     def open_analysis(self):
         url = "https://www.16personalities.com/{}-personality"
-        webbrowser.open_new(url.format(self.type.lower()))
+        webbrowser.open_new(url.format(self.type[0].lower()))
 
     def __call__(self, jarvis, s):
         prompt = "{black}Q{Q_id} {cyan}{left} {black}--- {green}{right}"


### PR DESCRIPTION
To fix the following issue:

**Issue occurred at Personality test #1261**

Line 65 was changed from this:

webbrowser.open_new(url.format(self.type.lower()))

to this:

webbrowser.open_new(url.format(self.type[0].lower()))