### PR TITLE
Added Telegram & Gmail messaging plugins

### DIFF
--- a/jarviscli/__main__.py
+++ b/jarviscli/__main__.py
@@ -2,6 +2,7 @@
 import Jarvis
 import colorama
 import sys
+from jarviscli.plugins.message import send_join_message
 
 
 def check_python_version():
@@ -13,6 +14,10 @@ def main():
     colorama.init()
     # start Jarvis
     jarvis = Jarvis.Jarvis()
+
+    # Send Telegram message on startup
+    send_join_message()
+
     command = " ".join(sys.argv[1:]).strip()
     jarvis.executor(command)
 

--- a/jarviscli/plugins/message.py
+++ b/jarviscli/plugins/message.py
@@ -1,0 +1,82 @@
+from plugin import plugin
+import smtplib
+import requests
+import os
+
+# --- Telegram Plugin ---
+@plugin("send telegram")
+def send_telegram(jarvis, s):
+    """
+    Send a message through Telegram.
+    Usage: send telegram <message>
+    """
+    # Get credentials from environment variables
+    TELEGRAM_BOT_TOKEN = os.environ.get("JARVIS_TELEGRAM_BOT_TOKEN")
+    CHAT_ID = os.environ.get("JARVIS_TELEGRAM_CHAT_ID")
+
+    if not TELEGRAM_BOT_TOKEN or not CHAT_ID:
+        jarvis.say("Telegram credentials are missing! Please set JARVIS_TELEGRAM_BOT_TOKEN and JARVIS_TELEGRAM_CHAT_ID.")
+        return
+
+    if not s:
+        jarvis.say("What message should I send?")
+        return
+
+    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+    data = {"chat_id": CHAT_ID, "text": s}
+
+    try:
+        response = requests.post(url, data=data)
+        if response.ok:
+            jarvis.say("Message sent via Telegram!")
+        else:
+            jarvis.say(f"Failed to send Telegram message. Status: {response.status_code}")
+    except Exception as e:
+        jarvis.say(f"Error sending Telegram message: {e}")
+
+
+# --- Gmail Plugin ---
+@plugin("send gmail")
+def send_gmail(jarvis, s):
+    """
+    Send a message through Gmail.
+    Usage: send gmail <message>
+    """
+    EMAIL = os.environ.get("JARVIS_GMAIL_ADDRESS")
+    PASSWORD = os.environ.get("JARVIS_GMAIL_APP_PASSWORD")
+
+    if not EMAIL or not PASSWORD:
+        jarvis.say("Gmail credentials are missing! Please set JARVIS_GMAIL_ADDRESS and JARVIS_GMAIL_APP_PASSWORD.")
+        return
+
+    if not s:
+        jarvis.say("What message should I send?")
+        return
+
+    try:
+        with smtplib.SMTP("smtp.gmail.com", 587) as server:
+            server.starttls()
+            server.login(EMAIL, PASSWORD)
+            server.sendmail(EMAIL, EMAIL, s)
+        jarvis.say("Email sent successfully!")
+    except Exception as e:
+        jarvis.say(f"Error sending email: {e}")
+
+
+def send_join_message():
+    """Send a startup message via Telegram."""
+    TELEGRAM_BOT_TOKEN = os.environ.get("JARVIS_TELEGRAM_BOT_TOKEN")
+    CHAT_ID = os.environ.get("JARVIS_TELEGRAM_CHAT_ID")
+
+    if not TELEGRAM_BOT_TOKEN or not CHAT_ID:
+        # Silently fail if credentials are not set
+        return
+
+    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+    data = {"chat_id": CHAT_ID, "text": "Jarvis is up and running!"}
+
+    try:
+        requests.post(url, data=data)
+    except Exception:
+        # Silently fail on error
+        pass


### PR DESCRIPTION
New Feature / Plugin Proposal: Issue #1266
This plugin allows Jarvis to send messages and alerts via:
Telegram Bot – using bot token + chat ID
Gmail – using SMTP with an app password

Current Functionality:
Sends a predefined message automatically when the system starts.
Notifications are delivered to the user’s Telegram and Gmail.so they know when the system starts and can prevent possible threats 

Future Potential:
Can be enhanced to send messages on demand via user commands.
Could support attachments, reminders, or multi-platform notifications.
Open for collaboration to expand its features and flexibility.