### PR TITLE
Fix import error: No module named 'jarviscli'

### DIFF
--- a/jarviscli/__main__.py
+++ b/jarviscli/__main__.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
-import Jarvis
-import colorama
+import os
 import sys
-from jarviscli.plugins.message import send_join_message
+
+import colorama
+
+
+PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+if PACKAGE_DIR not in sys.path:
+    sys.path.insert(0, PACKAGE_DIR)
+
+import Jarvis
+from plugins.message import send_join_message
 
 
 def check_python_version():


### PR DESCRIPTION
This pull request fixes import errors related to jarviscli modules.
Updated import statement in __main__.py
Make sure to use the correct module path
Fix Issue: #1276
This modification avoids the ModuleNotFoundError error when running Jarvis on the command line and ensures that the program loads the jarviscli module correctly.